### PR TITLE
CoreHaptics - Limit Json libs to Apple namespace

### DIFF
--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHHapticPattern.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHHapticPattern.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHHapticPatternMetaData.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHHapticPatternMetaData.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHSerializer.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/CHSerializer.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 
 using UnityEngine;
-using UnityJSON;
+using Apple.UnityJSON;
 
 #if UNITY_EDITOR
 using UnityEditor;

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioContinuousEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioContinuousEvent.cs
@@ -1,5 +1,5 @@
 using System;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioCustomEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioCustomEvent.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-using UnityJSON;
+using Apple.UnityJSON;
 using UnityEngine;
 
 #if UNITY_EDITOR

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticContinuousEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticContinuousEvent.cs
@@ -1,5 +1,5 @@
 using System;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticEvent.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticTransientEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticTransientEvent.cs
@@ -1,5 +1,5 @@
 using System;
-using UnityJSON;
+using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
 {

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Attributes.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Attributes.cs
@@ -1,8 +1,8 @@
-﻿using SimpleJSON;
+﻿using Apple.SimpleJSON;
 using System;
 using System.Collections.Generic;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// Defines the JSON serialization and deserialization options for a 

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Deserializer.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Deserializer.cs
@@ -1,11 +1,11 @@
-﻿using SimpleJSON;
+﻿using Apple.SimpleJSON;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// An exception during the deserialization process.

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Enums.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Enums.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityJSON
+﻿namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// Serialization/deserialization options for a single

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Instantiater.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Instantiater.cs
@@ -1,9 +1,9 @@
-﻿using SimpleJSON;
+﻿using Apple.SimpleJSON;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// An exception during the instantiation process.

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Interfaces.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Interfaces.cs
@@ -1,8 +1,8 @@
-﻿using SimpleJSON;
+﻿using Apple.SimpleJSON;
 using System;
 using System.Collections.Generic;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// Provides custom serialization for an object. If a

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/JSON.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/JSON.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// Provides high-level public API for the serialization and deserialization.

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Serializer.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Serializer.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	/// <summary>
 	/// Serializes an object into JSON string. Subclasses should override

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/SimpleJSON.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/SimpleJSON.cs
@@ -83,7 +83,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace SimpleJSON
+namespace Apple.SimpleJSON
 {
 	public enum JSONNodeType
 	{

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Util.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/UnityJSON/Util.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace UnityJSON
+namespace Apple.UnityJSON
 {
 	internal static class Util
 	{


### PR DESCRIPTION
Suggestion to keep UnityJSON/SimpleJSON inside of Apple namespace, preventing conflicts.