### PR TITLE
Fix: AppleCoreBuildStep disabling bitcode on tvOS

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
@@ -23,20 +23,23 @@ namespace Apple.Core
 #if UNITY_EDITOR_OSX
         public override void OnFinalizePostProcess(AppleBuildProfile appleBuildProfile, BuildTarget buildTarget, string pathToBuiltProject)
         {
-            Debug.Log($"AppleBuild: disabling Bitcode for framework and app targets.");
-            var pbxProject = AppleBuild.GetPbxProject(buildTarget, pathToBuiltProject);
-            var pbxProjectPath = AppleBuild.GetPbxProjectPath(buildTarget, pathToBuiltProject);
-
-            if (pbxProject != null)
+            if (buildTarget != BuildTarget.tvOS)
             {
-                var targetGuid = (buildTarget == BuildTarget.StandaloneOSX) ? pbxProject.TargetGuidByName(Application.productName) : pbxProject.GetUnityMainTargetGuid();
-                var frameworkGuid = pbxProject.GetUnityFrameworkTargetGuid();
+                Debug.Log($"AppleBuild: disabling Bitcode for framework and app targets.");
+                var pbxProject = AppleBuild.GetPbxProject(buildTarget, pathToBuiltProject);
+                var pbxProjectPath = AppleBuild.GetPbxProjectPath(buildTarget, pathToBuiltProject);
 
-                pbxProject.AddBuildProperty(frameworkGuid, "ENABLE_BITCODE", "false");
-                pbxProject.AddBuildProperty(targetGuid, "ENABLE_BITCODE", "false");
+                if (pbxProject != null)
+                {
+                    var targetGuid = (buildTarget == BuildTarget.StandaloneOSX) ? pbxProject.TargetGuidByName(Application.productName) : pbxProject.GetUnityMainTargetGuid();
+                    var frameworkGuid = pbxProject.GetUnityFrameworkTargetGuid();
 
-                Debug.Log($"AppleBuild: Writing bitcode changes to PBXProject {pbxProjectPath}...");
-                pbxProject.WriteToFile(pbxProjectPath);
+                    pbxProject.AddBuildProperty(frameworkGuid, "ENABLE_BITCODE", "false");
+                    pbxProject.AddBuildProperty(targetGuid, "ENABLE_BITCODE", "false");
+
+                    Debug.Log($"AppleBuild: Writing bitcode changes to PBXProject {pbxProjectPath}...");
+                    pbxProject.WriteToFile(pbxProjectPath);
+                }
             }
         }
 


### PR DESCRIPTION
Bitcode is required on tvOS; building without bitcode causes an error on upload to ASC.

This has been causing an error for me as I'm trying to upload a milestone build; bitcode is becoming disabled in my Unity tvOS builds, & I'd receive the following errors via an email from Apple:

> We identified one or more issues with a recent delivery for your app, "XYZ" 0.3 (903). Please correct the following issues, then upload again.
>
> ITMS-90496: Invalid Executable - The executable 'XYZ.app/Frameworks/AppleCoreNative.framework/AppleCoreNative' does not contain bitcode.
>
> ITMS-90496: Invalid Executable - The executable 'XYZ.app/Frameworks/GameKitWrapper.framework/GameKitWrapper' does not contain bitcode.
>
> ITMS-90496: Invalid Executable - The executable 'XYZ.app/Frameworks/UnityFramework.framework/UnityFramework' does not contain bitcode.
>
> ITMS-90496: Invalid Executable - The executable 'XYZ.app/XYZ' does not contain bitcode.

The problem may still persist otherwise, but I felt that this modification was still advised.

Note: I have also noticed that the [release notes for Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes) mention that bitcode is being deprecated & is no longer required in tvOS builds, so this fix may no longer be necessary once that version comes out of beta.