### PR TITLE
fix CopyAndEmbed compliation issue when compiling to iOS

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleFrameworkUtility.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleFrameworkUtility.cs
@@ -134,7 +134,7 @@ namespace Apple.Core
             {
                 Debug.Log($"Getting portion of source path {source} that comes after {searchString}");
                 var expectedInstallPath = source.Substring(source.LastIndexOf(searchString) + searchString.Length);
-                fileGuid = pbxProject.FindFileGuidByProjectPath(Path.Combine("Frameworks", expectedInstallPath));
+                fileGuid = pbxProject.FindFileGuidByProjectPath(Path.Combine(frameworkName.EndsWith(".a") ? "Libraries" : "Frameworks", expectedInstallPath));
                 if (string.IsNullOrEmpty(fileGuid))
                 {
                     Debug.LogError($"CopyAndEmbed expected to find an existing GUID for {frameworkName} at {expectedInstallPath} but could not be found.");


### PR DESCRIPTION
Fix the compiling error on iOS platform. 

**Error building Player: CopyAndEmbed expected to find an existing GUID for AudioPluginPHASE.a at com.apple.phase/Runtime/Plugins/iOS/AudioPluginPHASE.a but could not be found.**

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/2534431/189506688-7fec5e34-8127-4eb2-8e37-4ba1a7d0bff7.png">
