### PR TITLE
Fix AssetDatabase.FindAssets frameworks

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleFrameworkUtility.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleFrameworkUtility.cs
@@ -43,6 +43,23 @@ namespace Apple.Core
                 }
             }
 
+            // try without the .framework, Unity.2022 AssetDatabase.FindAssets fails with ".frameworks" 
+            if( libraryName.EndsWith(".framework") )
+            {
+                string libraryNameWithoutFramework = libraryName.Substring( 0, libraryName.LastIndexOf(".framework") );
+                results = AssetDatabase.FindAssets(libraryNameWithoutFramework);
+                foreach (string currGUID in results)
+                {
+                    string libraryPath = AssetDatabase.GUIDToAssetPath(currGUID);
+                    string[] folders = libraryPath.Split('/');
+                    if (Array.IndexOf(folders, platformString) > -1)
+                    {
+                        return libraryPath;
+                    }
+                }
+
+            }
+
             return string.Empty;
         }
 


### PR DESCRIPTION
In Unity 2022.2 fails to find the plugin ".frameworks" folder and breaks builds. 
Xcode will compile but then apps crash at startup as they can't find the frameworks.
AssetDatabase.FindAssets seems to ignore any suffixes.
This fixes the framework search.