### PR TITLE
Support batchmode with "quit" flag on

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
@@ -105,6 +105,7 @@ namespace Apple.Core
         /// </summary>
         private enum UpdateState
         {
+            NotInitialized,
             Initializing,
             Updating
         }
@@ -132,7 +133,9 @@ namespace Apple.Core
         /// </summary>
         private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
         {
-            if (_updateState != UpdateState.Initializing) { return; }
+            if (_updateState != UpdateState.NotInitialized) { return; }
+            
+            _updateState = UpdateState.Initializing;
             
             // Ensure that the necessary Apple Unity Plug-In support folders exist and let user know if any have been created.
             string createFolderMessage = "[Apple Unity Plug-ins] Creating support folders:\n";
@@ -172,7 +175,6 @@ namespace Apple.Core
             _packageManagerListRequest = Client.List();
 
             // Initialize state tracking
-            _updateState = UpdateState.Initializing;
             _trackedAppleConfig = GetAppleBuildConfig();
             _trackedApplePlatform = GetApplePlatformID(EditorUserBuildSettings.activeBuildTarget);
 

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
@@ -38,9 +38,8 @@ namespace Apple.Core
         } 
     }
 
-    [InitializeOnLoad]
-    public static class ApplePlugInEnvironment
-    {
+    public class ApplePlugInEnvironment : AssetPostprocessor
+    {   
         /// <summary>
         /// Name of the folder that the Apple Unity Plug-Ins will use for storing permanent data assets and helper objects
         /// </summary>
@@ -129,9 +128,9 @@ namespace Apple.Core
         private static string _trackedApplePlatform;
 
         /// <summary>
-        /// Static constructor used by Unity for initialization of the ApplePlugInEnvironment.
+        /// Initialize the ApplePlugInEnvironment after all assets finished processing, so we can alter our own.
         /// </summary>
-        static ApplePlugInEnvironment()
+        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
         {
             // Ensure that the necessary Apple Unity Plug-In support folders exist and let user know if any have been created.
             string createFolderMessage = "[Apple Unity Plug-ins] Creating support folders:\n";

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
@@ -130,8 +130,10 @@ namespace Apple.Core
         /// <summary>
         /// Initialize the ApplePlugInEnvironment after all assets finished processing, so we can alter our own.
         /// </summary>
-        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
         {
+            if (_updateState != UpdateState.Initializing) { return; }
+            
             // Ensure that the necessary Apple Unity Plug-In support folders exist and let user know if any have been created.
             string createFolderMessage = "[Apple Unity Plug-ins] Creating support folders:\n";
             bool foldersCreated = false;


### PR DESCRIPTION
## Changes

Currently, compiling a game with Apple.Core while in batch mode results in native libraries not being found. That occurs due to the following issues:

### 1. Creating assets during InitializeOnLoad
According to this [Unity issue](https://issuetracker-mig.prd.it.unity3d.com/issues/unable-to-import-newly-created-asset-errors-are-logged-when-creating-a-material-from-initializeonload), assets cannot be created on InitializeOnLoad, because the asset importing is not yet completed at that stage. This was causing a UnityException when building my game due to Apple.Core not being able to load the Default Profile asset, even though it is present in the repository. All the assets creation and retrival were moved to OnPostprocessAllAssets, which, according to the above mentioned Unity issue, is also called after domain reload, but only after all assets have been imported.

### 2. Using asynchronous coroutines while using `-quit` argument
`ApplePlugInEnvironment` relies on EditorUpdate to wait for the PackageManager to complete, which will not work on -batchmode -quit. In this case, we have to call EditorUpdate manually
