### PR TITLE
Support Apple.Core as an indirect dependency

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
@@ -168,7 +168,7 @@ namespace Apple.Core
 
             // Initialize collection of packages
             _appleUnityPackages = new Dictionary<string, AppleUnityPackage>();
-            _packageManagerListRequest = Client.List();
+            _packageManagerListRequest = Client.List(false, true);
 
             // Initialize state tracking
             _updateState = UpdateState.Initializing;


### PR DESCRIPTION
## Changes

* Fix Apple.Core does not find native binaries when it is an indirect dependency

## Steps to reproduce

1. Create a Unity package
2. Reference Apple.Core in the package and NOT on the main Unity project
3. Notice how the plugin does not find native binaries