### PR TITLE
Fix native libraries when there is only one platform

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleUnityPackage.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleUnityPackage.cs
@@ -44,7 +44,7 @@ namespace Apple.Core
                                 // Verified a valid config, create an inner dictionary for this config
                                 _nativeLibraryCollection[configFolderName] = new Dictionary<string, AppleNativeLibrary>();
                                 string[] platformPaths = Directory.GetDirectories(currConfigPath);
-                                if (platformPaths.Length > 1)
+                                if (platformPaths.Length > 0)
                                 {
                                     foreach (string currPlatformPath in platformPaths)
                                     {


### PR DESCRIPTION
Fix Apple.Core doesn't find native libraries when there is only one platform (FairPlay only has macOS binaries, for example)