### PR TITLE
Fix to remove a per-frame allocation causing garbage collects

### DIFF
--- a/plug-ins/Apple.GameController/Apple.GameController_Unity/Assets/Apple.GameController/Source/Controller/GCController.cs
+++ b/plug-ins/Apple.GameController/Apple.GameController_Unity/Assets/Apple.GameController/Source/Controller/GCController.cs
@@ -175,10 +175,12 @@ namespace Apple.GameController.Controller
 
         public void Poll()
         {
-            _previousButtonPressStates = new Dictionary<GCControllerInputName, bool>(_buttonPressStates);            
-            foreach (var key in _buttonPressStates.Keys.ToList())
+            _previousButtonPressStates.Clear();
+            foreach (var kv in _buttonPressStates)
             {
-                _buttonPressStates[key] = false;
+                _previousButtonPressStates.Add(kv.Key, kv.Value);
+                _buttonPressStates[kv.Key] = false;
+
             }
 
             InputState = IsConnected ? GCControllerService.PollController(Handle) : GCControllerInputState.None;
@@ -192,3 +194,4 @@ namespace Apple.GameController.Controller
         }
     }
 } 
+


### PR DESCRIPTION
A bit nit-picky. But this was causing us frame hitches due to garbage collection. (We run alloc free during main gameplay and right up to the edge of performance on lower spec devices.)