### PR TITLE
Fix paths with spaces in $APPLE_PLUGIN_LIBRARY_ROOT for Apple.Core

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
@@ -382,7 +382,7 @@ namespace Apple.Core
             + "dstFrameworkFolder=\"$BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH\"\n"
             + "dstBundleFolder=\"$BUILT_PRODUCTS_DIR/$PLUGINS_FOLDER_PATH\"\n"
             + $"APPLE_PLUGIN_LIBRARY_ROOT=\"$PROJECT_DIR/{projectRelativeNativeLibraryRoot}\"\n"
-            + "if [ -d $APPLE_PLUGIN_LIBRARY_ROOT ]; then\n"
+            + "if [ -d \"$APPLE_PLUGIN_LIBRARY_ROOT\" ]; then\n"
             + "    for folder in \"$APPLE_PLUGIN_LIBRARY_ROOT\"/*; do\n"
             + "        if [ -d \"$folder\" ]; then\n"
             + "            for item in \"$folder\"/*; do\n"

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
@@ -432,7 +432,7 @@ namespace Apple.Core
             + "echo \"Embed framework destination folder: $dstFrameworkFolder\"\n"
             + "echo \"Embed bundle destination folder: $dstBundleFolder\"\n"
             + $"APPLE_PLUGIN_LIBRARY_ROOT=\"$PROJECT_DIR/{projectRelativeNativeLibraryRoot}\"\n"
-            + "if [ -d $APPLE_PLUGIN_LIBRARY_ROOT ]; then\n"
+            + "if [ -d \"$APPLE_PLUGIN_LIBRARY_ROOT\" ]; then\n"
             + "    echo \"Found Apple plug-in native library root: $APPLE_PLUGIN_LIBRARY_ROOT\"\n"
             + "    echo \"Iterating through contents.\"\n"
             + "    for folder in \"$APPLE_PLUGIN_LIBRARY_ROOT\"/*; do\n"


### PR DESCRIPTION
When trying to build our Unity project in a particular path that had spaces in it, we encountered this error:

> No Apple plug-in library path found at /Users/Lartu/No Sync/[redacted] Build/ApplePluginLibraries
> Please check the Unity Editor build output and/or logs for issues and errors.
> Command PhaseScriptExecution failed with a nonzero exit code

This prevented us from building and Googling this issue yielded no fixes. In the end, it turns out that the build script for the *Embed Apple Plug-in Libraries* Build Phase does not enclose the `$APPLE_PLUGIN_LIBRARY_ROOT` variable with double quotes in the first conditional that checks for the existence of the library directory. This results in paths with spaces becoming multiple arguments for the `[` command of the `if` line, which crashes the build process:

![image](https://github.com/user-attachments/assets/ab3fed9d-b446-401b-a282-50b2e5b0e58c)

I've thus enclosed the variable with double quotes so this script works with paths that have spaces in them.

