### PR TITLE
Fix crash in osVersions list for Unknown RuntimeEnvironment

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/AvailabilityAttributes.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/AvailabilityAttributes.cs
@@ -63,7 +63,7 @@ namespace Apple.Core
 
         public override bool IsAvailable(RuntimeEnvironment env)
         {
-            var osVersion = _osVersions[env.RuntimeOperatingSystem];
+            _osVersions.TryGetValue(env.RuntimeOperatingSystem, out var osVersion);
             return 
                 osVersion.HasValue &&
                 ((env.VersionNumber.Major > osVersion.Value.Major) ||
@@ -136,7 +136,7 @@ namespace Apple.Core
 
         public override bool IsAvailable(RuntimeEnvironment env)
         {
-            var osVersion = _osVersions[env.RuntimeOperatingSystem];
+            _osVersions.TryGetValue(env.RuntimeOperatingSystem, out var osVersion);
             var isObsoleted = 
                 osVersion.HasValue &&
                 ((env.VersionNumber.Major > osVersion.Value.Major) ||


### PR DESCRIPTION
**Issue**

When trying to display a GKMatachmakerViewController request on iOS (tested on iPhone 8 iOS 16.7.10 and iPhone Xs iOS 17.6.1) an exception occurred with the following callstack :
```
KeyNotFoundException: The given key 'Unknown' was not present in the dictionary.
  at System.Collections.Generic.SortedList`2[TKey,TValue].get_Item (TKey key) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.Core.IntroducedAttribute.IsAvailable (Apple.Core.RuntimeEnvironment env) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.Core.Availability+<>c__DisplayClass6_0.<IsAvailable>b__0 (System.Attribute attr) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Linq.Enumerable.Any[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.Core.Availability.IsAvailable (System.Attribute[] attrs, Apple.Core.RuntimeEnvironment env) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.Core.Availability.IsMemberAvailable (System.Reflection.MemberInfo memberInfo, Apple.Core.RuntimeEnvironment env) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.GameKit.Multiplayer.GKMatchmakerViewController.Request (Apple.GameKit.Multiplayer.GKMatchRequest matchRequest, Apple.GameKit.Multiplayer.GKMatchmakingMode mode, System.Boolean canStartWithMinimumPlayers, Apple.GameKit.Multiplayer.GKMatchmakerViewControllerDelegate+GetMatchPropertiesForRecipientHandler getMatchPropertiesForRecipientHandler) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[TResult].Start[TStateMachine] (TStateMachine& stateMachine) [0x00000] in <00000000000000000000000000000000>:0 
  at Apple.GameKit.Multiplayer.GKMatchmakerViewController.Request (Apple.GameKit.Multiplayer.GKMatchRequest matchRequest, Apple.GameKit.Multiplayer.GKMatchmakingMode mode, System.Boolean canStartWithMinimumPlayers, Apple.GameKit.Multiplayer.GKMatchmakerViewControllerDelegate+GetMatchPropertiesForRecipientHandler getMatchPropertiesForRecipientHandler) [0x00000] in <00000000000000000000000000000000>:0 
```

**Expected behaviour :**

The application should not crash with an Unknown RuntimeEnvironment.

**Fix :**

Add `TryGetValue` when accessing the list.
