### PR TITLE
Fix OnApplicationStart DllNotFoundException in Unity Editor for Windows

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/Availability.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/Availability.cs
@@ -8,11 +8,14 @@ namespace Apple.Core
 {
     public static class Availability
     {
+#if (UNITY_EDITOR_OSX && (UNITY_IOS || UNITY_TVOS || UNITY_STANDALONE_OSX || UNITY_VISIONOS))
         [DllImport(InteropUtility.DLLName, EntryPoint = "AppleCore_GetRuntimeEnvironment")]
         private static extern RuntimeEnvironment AppleCore_GetRuntimeEnvironment();
-
-        private static RuntimeEnvironment _runtimeEnvironment;
         public static RuntimeEnvironment RuntimeEnvironment => _runtimeEnvironment.IsUnknown ? (_runtimeEnvironment = AppleCore_GetRuntimeEnvironment()) : _runtimeEnvironment;
+#else
+        public static RuntimeEnvironment RuntimeEnvironment => _runtimeEnvironment;
+#endif // (UNITY_EDITOR_OSX && (UNITY_IOS || UNITY_TVOS || UNITY_STANDALONE_OSX || UNITY_VISIONOS))
+        private static RuntimeEnvironment _runtimeEnvironment;
 
         /// <summary>
         /// Use to ensure API methods are only called on platforms which support those calls.


### PR DESCRIPTION
**Issue**

When starting the Unity Editor on Windows while using AppleUnityPlugins, we get the following error:
```
DllNotFoundException: AppleCoreNativeMac assembly:<unknown assembly> type:<unknown type> member:(null)
Apple.Core.Availability.OnApplicationStart () (at ./Packages/com.apple.unityplugin.core/Runtime/Availability.cs:13)
```

**Expected behaviour**

We should not get any Error in the Editor.

**Fix**

Add ifdef around the Dll imported methods.