### PR TITLE
Fixed plugin embedding build phase for macOS not being added on older versions of Unity

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuild.cs
@@ -199,7 +199,8 @@ namespace Apple.Core
             if (pbxProject != null)
             {
                 string projectRelativeNativeLibraryRoot = AppleNativeLibraryUtility.GetDestinationNativeLibraryFolderRoot(buildTarget);
-                pbxProject.AddShellScriptBuildPhase(pbxProject.GetUnityMainTargetGuid(), "Embed Apple Plug-in Libraries", "/bin/sh", GenerateEmbedNativeLibraryShellScript(projectRelativeNativeLibraryRoot));
+                var targetGuid = buildTarget == BuildTarget.StandaloneOSX ? pbxProject.TargetGuidByName(Application.productName) : pbxProject.GetUnityMainTargetGuid();
+                pbxProject.AddShellScriptBuildPhase(targetGuid, "Embed Apple Plug-in Libraries", "/bin/sh", GenerateEmbedNativeLibraryShellScript(projectRelativeNativeLibraryRoot));
                 pbxProject.WriteToFile(pbxProjectPath);
             }
 

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
@@ -21,7 +21,7 @@ namespace Apple.Core
             if (pbxProject != null)
             {
                 var targetGuid = buildTarget == BuildTarget.StandaloneOSX ? pbxProject.TargetGuidByName(Application.productName) : pbxProject.GetUnityMainTargetGuid();
-                pbxProject.AddBuildProperty(buildTarget, "ENABLE_BITCODE", "NO");
+                pbxProject.AddBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
 
                 if (buildTarget != BuildTarget.StandaloneOSX)
                 {

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
@@ -20,7 +20,8 @@ namespace Apple.Core
             var pbxProject = AppleBuild.GetPbxProject(buildTarget, generatedProjectPath);
             if (pbxProject != null)
             {
-                pbxProject.AddBuildProperty(pbxProject.GetUnityMainTargetGuid(), "ENABLE_BITCODE", "NO");
+                var targetGuid = buildTarget == BuildTarget.StandaloneOSX ? pbxProject.TargetGuidByName(Application.productName) : pbxProject.GetUnityMainTargetGuid();
+                pbxProject.AddBuildProperty(buildTarget, "ENABLE_BITCODE", "NO");
 
                 if (buildTarget != BuildTarget.StandaloneOSX)
                 {


### PR DESCRIPTION
On some older versions of Unity the `pbxProject.GetUnityMainTargetGuid()` for macOS build target returns empty string. In some places in code there is a ternary operator to address this (e.g. `AppleBuild.cs` line 176). [The issue is fixed in newer versions of Unity.](https://discussions.unity.com/t/pbxproject-getunitymaintargetguid-returns-empty-string-on-macos-api-inconsistencies-with-ios/834170/5)

This PR adds ternary operator in two places where the workaround was missing. Without that the "Embed Apple Plug-in Libraries" build phase was never added to the Xcode project and there was an Error Log in the Unity console. (Tested in Unity 2021.3.16f1)