### PR TITLE
CoreHaptics: Fixed missing CultureInfo while serializing floats

### DIFF
--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioContinuousEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioContinuousEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
@@ -25,7 +26,7 @@ namespace Apple.CoreHaptics
         public override string Serialize(Serializer serializer) {
             var ret = "{\n";
             ret += SerializeTypeAndTime();
-            ret += $",\n\t\t\t\t\"EventDuration\": {EventDuration}";
+            ret += $",\n\t\t\t\t\"EventDuration\": {EventDuration.ToString(new CultureInfo("en-US", false))}";
 
             ret += SerializeEventParams();
 

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioCustomEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticAudioCustomEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 
 using Apple.UnityJSON;
@@ -84,7 +85,7 @@ namespace Apple.CoreHaptics
             ret += SerializeTypeAndTime();
             ret += ",\n";
             if (EventDuration > 0) {
-                ret += $"\t\t\t\t\"EventDuration\": {EventDuration},\n";
+                ret += $"\t\t\t\t\"EventDuration\": {EventDuration.ToString(new CultureInfo("en-US", false))},\n";
             }
 
             ret += $"\t\t\t\t\"EventWaveformPath\": \"{EventWaveformPath}\"";

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticContinuousEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticContinuousEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
@@ -25,7 +26,7 @@ namespace Apple.CoreHaptics
         public override string Serialize(Serializer serializer) {
             var ret = "{\n";
             ret += SerializeTypeAndTime();
-            ret += $",\n\t\t\t\t\"EventDuration\": {EventDuration}";
+            ret += $",\n\t\t\t\t\"EventDuration\": {EventDuration.ToString(new CultureInfo("en-US", false))}";
 
             ret += SerializeEventParams();
 

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticEvent.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Source/PatternComponents/HapticEvents/CHHapticEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Apple.UnityJSON;
 
 namespace Apple.CoreHaptics
@@ -22,7 +23,7 @@ namespace Apple.CoreHaptics
 
         internal string SerializeTypeAndTime() {
             var ret = $"\t\t\t\t\"EventType\": \"{EventType}\",\n";
-            ret += $"\t\t\t\t\"Time\": {Time}";
+            ret += $"\t\t\t\t\"Time\": {Time.ToString(new CultureInfo("en-US", false))}";
             return ret;
         }
 
@@ -33,7 +34,7 @@ namespace Apple.CoreHaptics
 
                 for (var idx = 0; idx < EventParameters.Count; idx++) {
                     var ep = EventParameters[idx];
-                    ret += $"\n\t\t\t\t\t{{\"ParameterID\": \"{ep.ParameterID}\", \"ParameterValue\": {ep.ParameterValue}}}";
+                    ret += $"\n\t\t\t\t\t{{\"ParameterID\": \"{ep.ParameterID}\", \"ParameterValue\": {ep.ParameterValue.ToString(new CultureInfo("en-US", false))}}}";
 
                     // Add a comma for all but the last Param
                     if (idx != EventParameters.Count - 1) {


### PR DESCRIPTION
When the device's region is where the decimal point is `,` instead of `.`, CoreHaptics API throws exception. The reason is while serializing the parameters, it has done with the device's region, but while deserializing them, "en-US" region is considered.

This PR adds "en-US" CultureInfo while serializing these parameters.