### PR TITLE
fix: Corehaptics.AssetPickerDrawer throws exceptions and draws incorrectly when fieldInfo or assetType is null 

### DIFF
--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPickerDrawer.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPickerDrawer.cs
@@ -10,6 +10,13 @@ namespace UnityPickers
 	{
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
+			if (fieldInfo == null)
+			{
+				// If fieldInfo is null, draw the property field as is.
+				EditorGUI.PropertyField(position, property, label);
+				return;
+			}
+			
 			var assetType = fieldInfo.FieldType;
 			if (assetType.IsUnityCollection())
 				assetType = assetType.GetElementType();

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPickerDrawer.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPickerDrawer.cs
@@ -22,7 +22,11 @@ namespace UnityPickers
 				assetType = assetType.GetElementType();
 
 			if (assetType == null)
+			{
+				// If assetType is null, draw the property field as is.
+				EditorGUI.PropertyField(position, property, label);
 				return;
+			}
 
 			var a = fieldInfo.GetAttribute<AssetPickerAttribute>();
 


### PR DESCRIPTION
I'm having problems with collections of `ScriptableObject`s on inspector.
For example:
```csharp
using System.Collections.Generic;
using UnityEngine;

public class Test : MonoBehaviour
{
    public List<ScriptableObject> scriptableObjects;
}
```
It is rendered on inspector like this: 
<img width="459" alt="Screenshot 2025-02-05 at 14 56 53" src="https://github.com/user-attachments/assets/dfacbe43-9647-4f56-ad00-99cbfec71a50" />
But it was supposed to look like this:
<img width="459" alt="Screenshot 2025-02-05 at 14 57 05" src="https://github.com/user-attachments/assets/09183ba3-0367-4bb0-8c52-9cbe563073c2" />

The issue is caused by `CoreHaptics.AssetPickerDrawer`

This PR fixes this issue by drawing the `PropertyField` as is, if `fieldInfo` or `assetType` is null.

PS: I'm using Unity 6.