### PR TITLE
NSData default constructor to avoid stripping

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/NSData.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/NSData.cs
@@ -23,6 +23,13 @@ namespace Apple.Core.Runtime
         public NSData(byte[] bytes) : base(InitWithBytes(bytes))
         {
         }
+        
+        /// <summary>
+        /// Default constructor that initializes an empty NSData instance.
+        /// </summary>
+        public NSData() : base(CreateEmptyNSData())
+        {
+        }
 
         private static IntPtr InitWithBytes(byte[] bytes)
         {
@@ -66,12 +73,23 @@ namespace Apple.Core.Runtime
         /// Helper method to get the byte array from an interop IntPtr to NSData.
         /// </summary>
         public static byte[] GetBytes(IntPtr pointer) => (pointer != default) ? new NSData(pointer).Bytes : Array.Empty<byte>();
+        
+        /// <summary>
+        /// Creates an empty NSData instance using a native method.
+        /// </summary>
+        /// <returns>Pointer to the newly created empty NSData object.</returns>
+        private static IntPtr CreateEmptyNSData()
+        {
+            return Interop.NSData_Empty(NSException.ThrowOnExceptionCallback);
+        }
 
         private static class Interop
         {
             [DllImport(InteropUtility.DLLName)] public static extern IntPtr NSData_InitWithBytes(IntPtr bytes, UInt64 length, NSExceptionCallback onException);
             [DllImport(InteropUtility.DLLName)] public static extern UInt64 NSData_GetLength(IntPtr nsDataPtr, NSExceptionCallback onException);
             [DllImport(InteropUtility.DLLName)] public static extern IntPtr NSData_GetBytes(IntPtr nsDataPtr, NSExceptionCallback onException);
+            [DllImport(InteropUtility.DLLName)] public static extern IntPtr NSData_Empty(NSExceptionCallback onException);
+
         }
     }
 }

--- a/plug-ins/Apple.Core/Native/AppleCoreNative/NSData.m
+++ b/plug-ins/Apple.Core/Native/AppleCoreNative/NSData.m
@@ -40,3 +40,14 @@ const void * NSData_GetBytes(void * nsDataPtr, void (* exceptionCallback)(void *
     }
     return 0;
 }
+
+const void * NSData_Empty(void (*exceptionCallback)(void * nsExceptionPtr)) {
+    @try {
+        NSData *data = [NSData data];
+        return (__bridge_retained const void *)data;
+    }
+    @catch (NSException * e) {
+        exceptionCallback((void *)CFBridgingRetain(e));
+    }
+    return NULL;
+}


### PR DESCRIPTION
These changes add a way to get an empty NSData using a default constructor.
This is needed since [GKLocalPlayer.Local.FetchItems()](https://github.com/apple/unityplugins/blob/f93244004ff4fb07d50445bcd7832218e7c4321e/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKLocalPlayer.cs#L57) eventually calls [OnFetchItems](https://github.com/apple/unityplugins/blob/f93244004ff4fb07d50445bcd7832218e7c4321e/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKLocalPlayer.cs#L62) which requires to create an empty NSData at the moment of deserialization.