### PR TITLE
Fix GKGameActivity Initializer

### DIFF
--- a/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKGameActivity.cs
+++ b/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/GKGameActivity.cs
@@ -32,7 +32,10 @@ namespace Apple.GameKit
 
         static GKGameActivity()
         {
-            Interop.GKGameActivity_SetWantsToPlayCallback(OnWantsToPlay);
+            if (Availability.IsTypeAvailable<GKGameActivity>())
+            {
+                Interop.GKGameActivity_SetWantsToPlayCallback(OnWantsToPlay);
+            }
         }
 
 #if IOS_19_BETA_1_WANTSTOPLAY_MAIN_THREAD_WORKAROUND


### PR DESCRIPTION
Fix #60
GKGameActivity has a static initializer that was being called regardless of system support. The static initializer needs to check availability first.
