### PR TITLE
Spatial Controller Memory Leak

### DIFF
--- a/plug-ins/Apple.SpatialController/Native/SpatialController/Extensions.swift
+++ b/plug-ins/Apple.SpatialController/Native/SpatialController/Extensions.swift
@@ -481,6 +481,7 @@ extension SCAccessory {
         usdzFile = nil
         description.deallocate()
         description = nil
+        locations.deallocate()
         source.deallocate()
     }
 }
@@ -727,6 +728,8 @@ extension SCControllerState {
         input.deallocate()
         anchors.deallocate()
         if accessory != nil {
+            var a = accessory.pointee
+            a.deallocate()
             accessory.deallocate()
             accessory = nil
         }


### PR DESCRIPTION
1. locations were never freed.
2. every PollController call, everything inside inside accessory pointer never freed.