### PR TITLE
Force reserialize the copied libraries

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/ApplePlugInEnvironment.cs
@@ -529,6 +529,7 @@ namespace Apple.Core
             bool librariesCopied = false;
 
             // Copy current
+            List<string> copiedAssetPaths = new List<string>();
             foreach (AppleUnityPackage applePackage in _appleUnityPackages.Values)
             {
                 if (applePackage.PlayModeSupportLibrary.IsValid)
@@ -536,7 +537,9 @@ namespace Apple.Core
                     librariesCopied = true;
                     AppleNativeLibrary pmsLibrary = applePackage.PlayModeSupportLibrary;
                     summary += $"\n  <b>{pmsLibrary.FileName}</b>";
-                    FileUtil.CopyFileOrDirectory(pmsLibrary.FullPath, $"{UnityProjectPath}/{ApplePlugInSupportPlayModeSupportPath}/{pmsLibrary.FileName}");
+                    string assetPath = $"{ApplePlugInSupportPlayModeSupportPath}/{pmsLibrary.FileName}";
+                    FileUtil.CopyFileOrDirectory(pmsLibrary.FullPath, $"{UnityProjectPath}/{assetPath}");
+                    copiedAssetPaths.Add(assetPath);
                 }
             }
 
@@ -546,6 +549,15 @@ namespace Apple.Core
             }
 
             AssetDatabase.Refresh();
+
+            // When Unity detects new asset files, it will default to creating a minimal metadata file.
+            // The full data isn't serialized to the metadata until someone touches it or we force it to reserialize.
+            // We want the full metadata serialized, otherwise the metadata will keep ping-ponging between full
+            // and partial depending on someone touches the asset.
+            if(copiedAssetPaths.Count > 0)
+            {
+                AssetDatabase.ForceReserializeAssets(copiedAssetPaths, ForceReserializeAssetsOptions.ReserializeMetadata);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Goal & Changes
When `SyncronizePlayModeSupportLibraries()` is called, the metadata that is generated is a reduced metadata without all the fields serialized to it. Calling [AssetDatabase.ForceReserializeAssets()](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/AssetDatabase.ForceReserializeAssets.html) causes all the fields to be serialized to the metadata file. The issue is that if a project runs the `ForceReserializeAssets()` method and commits those changes, those modifications will be undone the next time `SyncronizePlayModeSupportLibraries()` is run - which happens as part of the [AssetPostprocessor](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/AssetPostprocessor.html) interface callbacks.

This change forces the metadata files associated with the syncronized libraries to be reserialized so that they always have the full serialized fields. Running [AssetDatabase.ForceReserializeAssets()](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/AssetDatabase.ForceReserializeAssets.html) will then not generate any diffs.

I have tried to minimise the workload as much as possible by only reserializing the syncronized libraries, and even then limit it to just the metadata by specific the flag: [ForceReserializeAssetsOptions.ReserializeMetadata](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/ForceReserializeAssetsOptions.ReserializeMetadata.html)