### PR TITLE
Set custom interop type names via attribute instead of static property

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/InteropTypeNameAttribute.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/InteropTypeNameAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Apple.Core
+{
+    /// <summary>
+    /// Attribute for manually specifying a class's corresponding Objective-C type name. This is required for classes
+    /// that do not share their C# type name with their Objective-C counterpart, such as nested classes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class InteropTypeNameAttribute : Attribute
+    {
+        public string TypeName { get; private set; }
+
+        public InteropTypeNameAttribute(string customTypeName)
+        {
+            TypeName = customTypeName;
+        }
+    }
+}

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/InteropTypeNameAttribute.cs.meta
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/InteropTypeNameAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6c3c61f3764d4688a279325a72606e82
+timeCreated: 1775773530

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/NSObject.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Runtime/NSObject.cs
@@ -38,8 +38,7 @@ namespace Apple.Core.Runtime
             var typeName = type.Name;
 
             // Special case for types that provide a custom interop type name.
-            if (type.GetProperty("InteropTypeName", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                    ?.GetValue(null) is string customTypeName)
+            if(type.GetCustomAttribute<InteropTypeNameAttribute>()?.TypeName is string customTypeName)
             {
                 typeName = customTypeName;
             }

--- a/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/Leaderboards/GKLeaderboard.cs
+++ b/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Source/Leaderboards/GKLeaderboard.cs
@@ -58,13 +58,11 @@ namespace Apple.GameKit.Leaderboards
         /// <summary>
         /// Information about a single score by a player on a leaderboard.
         /// </summary>
+        [InteropTypeName("GKLeaderboardEntry")]
         [Introduced(iOS: "14.0", macOS: "11.0", tvOS: "14.0", visionOS: "1.0")]
         public class Entry : NSObject
         {
             internal Entry(IntPtr pointer) : base(pointer) {}
-
-            // This allows interop to work with the Objective-C type which has a different name: GKLeaderboardEntry.
-            internal static string InteropTypeName => "GKLeaderboardEntry";
 
             /// <summary>
             /// An integer value that your game uses.


### PR DESCRIPTION
### Goal & Changes

`NSObject.GetInteropTypeName` attempts to derive the Objective-C class name that a C# type is wrapping by directly converting the name, which does not work for nested types such as `GKLeaderboard.Entry`. This could be overridden by means of a static property on the class named `InteropTypeName`, but because this was checked via reflection, it could easily be code-stripped and proved unreliable in builds.

To make this less reliant on reflection and more reliable, I've changed the technique to use a new attribute (`InteropTypeNameAttribute`) instead of a static property. `NSObject.GetInteropTypeName` now checks for the attribute instead of a static property. The one place this was used in the library (`GKLeaderboard.Entry`) has been updated.