### PR TITLE
Fix for apple/unityplugins#102 - obsolete method in Unity 6000.4 and newer versions throws error.

### DIFF
--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
@@ -1186,12 +1186,12 @@ namespace Apple.Accessibility
 #if UNITY_6000_4_OR_NEWER
         private delegate string AccessibilityCustomActionNameDelegate2(ulong identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName2(AccessibilityCustomActionNameDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionNameDelegate2))]
         private static string _UnityAX_CustomActionName2(ulong identifier, int idx)
 #else
         private delegate string AccessibilityCustomActionNameDelegate(int identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName(AccessibilityCustomActionNameDelegate actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionNameDelegate))]
         private static string _UnityAX_CustomActionName(int identifier, int idx)
 #endif
         {

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
@@ -388,32 +388,64 @@ namespace Apple.Accessibility
             UnregisterAXElement(this);
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private static Dictionary<ulong, AccessibilityNode> axElements = new Dictionary<ulong, AccessibilityNode>();
+#else
         private static Dictionary<int, AccessibilityNode> axElements = new Dictionary<int, AccessibilityNode>();
+#endif
 
         static internal void RegisterAXElement(AccessibilityNode obj)
         {
+#if UNITY_6000_4_OR_NEWER
+            if (axElements.ContainsKey(EntityId.ToULong(obj.gameObject.GetEntityId())))
+#else
             if (axElements.ContainsKey(obj.gameObject.GetInstanceID()))
+#endif
             {
                 return;
             }
+
+#if UNITY_6000_4_OR_NEWER
+            axElements.Add(EntityId.ToULong(obj.gameObject.GetEntityId()), obj);
+            AccessibilityNode parent = obj._accessibilityParent();
+            ulong parentId = EntityId.ToULong(EntityId.None);
+#else
             axElements.Add(obj.gameObject.GetInstanceID(), obj);
             AccessibilityNode parent = obj._accessibilityParent();
             int parentId = -1;
+#endif
 
             if (parent)
             {
+#if UNITY_6000_4_OR_NEWER
+                parentId = EntityId.ToULong(parent.gameObject.GetEntityId());
+#else
                 parentId = parent.gameObject.GetInstanceID();
+#endif
             }
+
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+#if UNITY_6000_4_OR_NEWER
+            _UnityAX_RegisterElementWithIdentifier2(EntityId.ToULong(obj.gameObject.GetEntityId()), parentId, parent != null);
+#else
             _UnityAX_RegisterElementWithIdentifier(obj.gameObject.GetInstanceID(), parentId, parent != null);
+#endif
 #endif
         }
 
         static internal void UnregisterAXElement(AccessibilityNode obj)
         {
+#if UNITY_6000_4_OR_NEWER
+            axElements.Remove(EntityId.ToULong(obj.gameObject.GetEntityId()));
+#else
             axElements.Remove(obj.gameObject.GetInstanceID());
+#endif
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+#if UNITY_6000_4_OR_NEWER
+            _UnityAX_UnregisterElementWithIdentifier2(EntityId.ToULong(obj.gameObject.GetEntityId()));
+#else
             _UnityAX_UnregisterElementWithIdentifier(obj.gameObject.GetInstanceID());
+#endif
 #endif
         }
 
@@ -870,7 +902,9 @@ namespace Apple.Accessibility
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")] private static extern void _UnityAX_InitializeAXRuntime();
         [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier(int identifier, int parentIdentifier, bool hasParent);
+        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier2(ulong identifier, ulong parentIdentifier, bool hasParent);
         [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier(int identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier2(ulong identifier);
 
         private delegate string AccessibilityFrameDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityFrame(AccessibilityFrameDelegate actionDelegate);

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
@@ -388,18 +388,14 @@ namespace Apple.Accessibility
             UnregisterAXElement(this);
         }
 
-#if UNITY_6000_4_OR_NEWER
         private static Dictionary<ulong, AccessibilityNode> axElements = new Dictionary<ulong, AccessibilityNode>();
-#else
-        private static Dictionary<int, AccessibilityNode> axElements = new Dictionary<int, AccessibilityNode>();
-#endif
 
         static internal void RegisterAXElement(AccessibilityNode obj)
         {
 #if UNITY_6000_4_OR_NEWER
             if (axElements.ContainsKey(EntityId.ToULong(obj.gameObject.GetEntityId())))
 #else
-            if (axElements.ContainsKey(obj.gameObject.GetInstanceID()))
+            if (axElements.ContainsKey((ulong)obj.gameObject.GetInstanceID()))
 #endif
             {
                 return;
@@ -410,9 +406,9 @@ namespace Apple.Accessibility
             AccessibilityNode parent = obj._accessibilityParent();
             ulong parentId = EntityId.ToULong(EntityId.None);
 #else
-            axElements.Add(obj.gameObject.GetInstanceID(), obj);
+            axElements.Add((ulong)obj.gameObject.GetInstanceID(), obj);
             AccessibilityNode parent = obj._accessibilityParent();
-            int parentId = -1;
+            ulong parentId = 0;
 #endif
 
             if (parent)
@@ -420,15 +416,15 @@ namespace Apple.Accessibility
 #if UNITY_6000_4_OR_NEWER
                 parentId = EntityId.ToULong(parent.gameObject.GetEntityId());
 #else
-                parentId = parent.gameObject.GetInstanceID();
+                parentId = (ulong)parent.gameObject.GetInstanceID();
 #endif
             }
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
 #if UNITY_6000_4_OR_NEWER
-            _UnityAX_RegisterElementWithIdentifier2(EntityId.ToULong(obj.gameObject.GetEntityId()), parentId, parent != null);
+            _UnityAX_RegisterElementWithIdentifier(EntityId.ToULong(obj.gameObject.GetEntityId()), parentId, parent != null);
 #else
-            _UnityAX_RegisterElementWithIdentifier(obj.gameObject.GetInstanceID(), parentId, parent != null);
+            _UnityAX_RegisterElementWithIdentifier((ulong)obj.gameObject.GetInstanceID(), parentId, parent != null);
 #endif
 #endif
         }
@@ -438,13 +434,13 @@ namespace Apple.Accessibility
 #if UNITY_6000_4_OR_NEWER
             axElements.Remove(EntityId.ToULong(obj.gameObject.GetEntityId()));
 #else
-            axElements.Remove(obj.gameObject.GetInstanceID());
+            axElements.Remove((ulong)obj.gameObject.GetInstanceID());
 #endif
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
 #if UNITY_6000_4_OR_NEWER
-            _UnityAX_UnregisterElementWithIdentifier2(EntityId.ToULong(obj.gameObject.GetEntityId()));
+            _UnityAX_UnregisterElementWithIdentifier(EntityId.ToULong(obj.gameObject.GetEntityId()));
 #else
-            _UnityAX_UnregisterElementWithIdentifier(obj.gameObject.GetInstanceID());
+            _UnityAX_UnregisterElementWithIdentifier((ulong)obj.gameObject.GetInstanceID());
 #endif
 #endif
         }
@@ -875,28 +871,7 @@ namespace Apple.Accessibility
             if (!__registered)
             {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-#if UNITY_6000_4_OR_NEWER
-                _UnityAX_InitializeAXRuntime(2);
-                _UnityAX_registerAccessibilityFrame2(_UnityAX_accessibilityFrame2);
-                _UnityAX_registerAccessibilityLabel2(_UnityAX_accessibilityLabel2);
-                _UnityAX_registerAccessibilityTraits2(_UnityAX_accessibilityTraits2);
-                _UnityAX_registerAccessibilityIsElement2(_UnityAX_IsAccessibilityElement2);
-                _UnityAX_registerAccessibilityHint2(_UnityAX_AccessibilityHint2);
-                _UnityAX_registerAccessibilityValue2(_UnityAX_AccessibilityValue2);
-                _UnityAX_registerAccessibilityIdentifier2(_UnityAX_AccessibilityIdentifier2);
-                _UnityAX_registerAccessibilityViewIsModal2(_UnityAX_AccessibilityViewIsModal2);
-                _UnityAX_registerAccessibilityActivationPoint2(_UnityAX_AccessibilityActivationPoint2);
-                _UnityAX_registerAccessibilityPerformMagicTap2(_UnityAX_AccessibilityPerformMagicTap2);
-                _UnityAX_registerAccessibilityPerformEscape2(_UnityAX_AccessibilityPerformEscape2);
-                _UnityAX_registerAccessibilityActivate2(_UnityAX_AccessibilityActivate2);
-                _UnityAX_registerAccessibilityIncrement2(_UnityAX_AccessibilityIncrement2);
-                _UnityAX_registerAccessibilityDecrement2(_UnityAX_AccessibilityDecrement2);
-                _UnityAX_registerAccessibilityScroll2(_UnityAX_AccessibilityScroll2);
-                _UnityAX_registerAccessibilityCustomActionsCount2(_UnityAX_AccessibilityCustomActionCount2);
-                _UnityAX_registerAccessibilityPerformCustomAction2(_UnityAX_PerformCustomAction2);
-                _UnityAX_registerAccessibilityCustomActionName2(_UnityAX_CustomActionName2);
-#else
-                _UnityAX_InitializeAXRuntime(0);
+                _UnityAX_InitializeAXRuntime();
                 _UnityAX_registerAccessibilityFrame(_UnityAX_accessibilityFrame);
                 _UnityAX_registerAccessibilityLabel(_UnityAX_accessibilityLabel);
                 _UnityAX_registerAccessibilityTraits(_UnityAX_accessibilityTraits);
@@ -916,33 +891,19 @@ namespace Apple.Accessibility
                 _UnityAX_registerAccessibilityPerformCustomAction(_UnityAX_PerformCustomAction);
                 _UnityAX_registerAccessibilityCustomActionName(_UnityAX_CustomActionName);
 #endif
-#endif
                 __registered = true;
             }
         }
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-        // Parameter callbackOption tells native code which set of calbacks to use. Valid values: 0, 2
-        [DllImport("__Internal")] private static extern void _UnityAX_InitializeAXRuntime(int callbackOption);
-#if UNITY_6000_4_OR_NEWER
-        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier2(ulong identifier, ulong parentIdentifier, bool hasParent);
-        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier2(ulong identifier);
-#else
-        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier(int identifier, int parentIdentifier, bool hasParent);
-        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier(int identifier);
-#endif
+        [DllImport("__Internal")] private static extern void _UnityAX_InitializeAXRuntime();
+        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier(ulong identifier, ulong parentIdentifier, bool hasParent);
+        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier(ulong identifier);
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityFrameDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityFrame2(AccessibilityFrameDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityFrameDelegate2))]
-        private static string _UnityAX_accessibilityFrame2(ulong identifier)
-#else
-        private delegate string AccessibilityFrameDelegate(int identifier);
+        private delegate string AccessibilityFrameDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityFrame(AccessibilityFrameDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityFrameDelegate))]
-        private static string _UnityAX_accessibilityFrame(int identifier)
-#endif
+        private static string _UnityAX_accessibilityFrame(ulong identifier)
         {
             Rect rect = Rect.zero;
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
@@ -952,17 +913,10 @@ namespace Apple.Accessibility
             return _stringForRect(rect);
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityLabelDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityLabel2(AccessibilityLabelDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityLabelDelegate2))]
-        private static string _UnityAX_accessibilityLabel2(ulong identifier)
-#else
-        private delegate string AccessibilityLabelDelegate(int identifier);
+        private delegate string AccessibilityLabelDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityLabel(AccessibilityLabelDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityLabelDelegate))]
-        private static string _UnityAX_accessibilityLabel(int identifier)
-#endif
+        private static string _UnityAX_accessibilityLabel(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -971,17 +925,10 @@ namespace Apple.Accessibility
             return null;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate ulong AccessibilityTraitsDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityTraits2(AccessibilityTraitsDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityTraitsDelegate2))]
-        private static ulong _UnityAX_accessibilityTraits2(ulong identifier)
-#else
-        private delegate ulong AccessibilityTraitsDelegate(int identifier);
+        private delegate ulong AccessibilityTraitsDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityTraits(AccessibilityTraitsDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityTraitsDelegate))]
-        private static ulong _UnityAX_accessibilityTraits(int identifier)
-#endif
+        private static ulong _UnityAX_accessibilityTraits(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -990,17 +937,10 @@ namespace Apple.Accessibility
             return 0;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool IsAccessibilityElementDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIsElement2(IsAccessibilityElementDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(IsAccessibilityElementDelegate2))]
-        private static bool _UnityAX_IsAccessibilityElement2(ulong identifier)
-#else
-        private delegate bool IsAccessibilityElementDelegate(int identifier);
+        private delegate bool IsAccessibilityElementDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIsElement(IsAccessibilityElementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(IsAccessibilityElementDelegate))]
-        private static bool _UnityAX_IsAccessibilityElement(int identifier)
-#endif
+        private static bool _UnityAX_IsAccessibilityElement(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1009,17 +949,10 @@ namespace Apple.Accessibility
             return true;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityHintDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityHint2(AccessibilityHintDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityHintDelegate2))]
-        private static string _UnityAX_AccessibilityHint2(ulong identifier)
-#else
-        private delegate string AccessibilityHintDelegate(int identifier);
+        private delegate string AccessibilityHintDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityHint(AccessibilityHintDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityHintDelegate))]
-        private static string _UnityAX_AccessibilityHint(int identifier)
-#endif
+        private static string _UnityAX_AccessibilityHint(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1028,17 +961,10 @@ namespace Apple.Accessibility
             return null;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityValueDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityValue2(AccessibilityValueDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityValueDelegate2))]
-        private static string _UnityAX_AccessibilityValue2(ulong identifier)
-#else
-        private delegate string AccessibilityValueDelegate(int identifier);
+        private delegate string AccessibilityValueDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityValue(AccessibilityValueDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityValueDelegate))]
-        private static string _UnityAX_AccessibilityValue(int identifier)
-#endif
+        private static string _UnityAX_AccessibilityValue(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1047,17 +973,10 @@ namespace Apple.Accessibility
             return null;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityIdentifierDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIdentifier2(AccessibilityIdentifierDelegate2 identifierDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityIdentifierDelegate2))]
-        private static string _UnityAX_AccessibilityIdentifier2(ulong identifier)
-#else
-        private delegate string AccessibilityIdentifierDelegate(int identifier);
+        private delegate string AccessibilityIdentifierDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIdentifier(AccessibilityIdentifierDelegate identifierDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityIdentifierDelegate))]
-        private static string _UnityAX_AccessibilityIdentifier(int identifier)
-#endif
+        private static string _UnityAX_AccessibilityIdentifier(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1066,17 +985,10 @@ namespace Apple.Accessibility
             return null;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityViewIsModalDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityViewIsModal2(AccessibilityViewIsModalDelegate2 viewIsModalDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityViewIsModalDelegate2))]
-        private static bool _UnityAX_AccessibilityViewIsModal2(ulong identifier)
-#else
-        private delegate bool AccessibilityViewIsModalDelegate(int identifier);
+        private delegate bool AccessibilityViewIsModalDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityViewIsModal(AccessibilityViewIsModalDelegate viewIsModalDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityViewIsModalDelegate))]
-        private static bool _UnityAX_AccessibilityViewIsModal(int identifier)
-#endif
+        private static bool _UnityAX_AccessibilityViewIsModal(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1085,17 +997,10 @@ namespace Apple.Accessibility
             return false;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityActivationPointDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivationPoint2(AccessibilityActivationPointDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityActivationPointDelegate2))]
-        private static string _UnityAX_AccessibilityActivationPoint2(ulong identifier)
-#else
-        private delegate string AccessibilityActivationPointDelegate(int identifier);
+        private delegate string AccessibilityActivationPointDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivationPoint(AccessibilityActivationPointDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityActivationPointDelegate))]
-        private static string _UnityAX_AccessibilityActivationPoint(int identifier)
-#endif
+        private static string _UnityAX_AccessibilityActivationPoint(ulong identifier)
         {
             Vector2 value = Vector2.positiveInfinity;
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
@@ -1105,17 +1010,10 @@ namespace Apple.Accessibility
             return value == Vector2.positiveInfinity ? null : _stringForPoint(value);
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityScrollDelegate2(ulong identifier, int direction);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityScroll2(AccessibilityScrollDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityScrollDelegate2))]
-        private static bool _UnityAX_AccessibilityScroll2(ulong identifier, int direction)
-#else
-        private delegate bool AccessibilityScrollDelegate(int identifier, int direction);
+        private delegate bool AccessibilityScrollDelegate(ulong identifier, int direction);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityScroll(AccessibilityScrollDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityScrollDelegate))]
-        private static bool _UnityAX_AccessibilityScroll(int identifier, int direction)
-#endif
+        private static bool _UnityAX_AccessibilityScroll(ulong identifier, int direction)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1124,17 +1022,10 @@ namespace Apple.Accessibility
             return false;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate void AccessibilityIncrementDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIncrement2(AccessibilityIncrementDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityIncrementDelegate2))]
-        private static void _UnityAX_AccessibilityIncrement2(ulong identifier)
-#else
-        private delegate void AccessibilityIncrementDelegate(int identifier);
+        private delegate void AccessibilityIncrementDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIncrement(AccessibilityIncrementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityIncrementDelegate))]
-        private static void _UnityAX_AccessibilityIncrement(int identifier)
-#endif
+        private static void _UnityAX_AccessibilityIncrement(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1142,17 +1033,10 @@ namespace Apple.Accessibility
             }
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate void AccessibilityDecrementDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityDecrement2(AccessibilityDecrementDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityDecrementDelegate2))]
-        private static void _UnityAX_AccessibilityDecrement2(ulong identifier)
-#else
-        private delegate void AccessibilityDecrementDelegate(int identifier);
+        private delegate void AccessibilityDecrementDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityDecrement(AccessibilityDecrementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityDecrementDelegate))]
-        private static void _UnityAX_AccessibilityDecrement(int identifier)
-#endif
+        private static void _UnityAX_AccessibilityDecrement(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1160,17 +1044,10 @@ namespace Apple.Accessibility
             }
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate ulong AccessibilityCustomActionsCountDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionsCount2(AccessibilityCustomActionsCountDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionsCountDelegate2))]
-        private static ulong _UnityAX_AccessibilityCustomActionCount2(ulong identifier)
-#else
-        private delegate ulong AccessibilityCustomActionsCountDelegate(int identifier);
+        private delegate ulong AccessibilityCustomActionsCountDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionsCount(AccessibilityCustomActionsCountDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionsCountDelegate))]
-        private static ulong _UnityAX_AccessibilityCustomActionCount(int identifier)
-#endif
+        private static ulong _UnityAX_AccessibilityCustomActionCount(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1183,17 +1060,10 @@ namespace Apple.Accessibility
             return 0;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate string AccessibilityCustomActionNameDelegate2(ulong identifier, int idx);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName2(AccessibilityCustomActionNameDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionNameDelegate2))]
-        private static string _UnityAX_CustomActionName2(ulong identifier, int idx)
-#else
-        private delegate string AccessibilityCustomActionNameDelegate(int identifier, int idx);
+        private delegate string AccessibilityCustomActionNameDelegate(ulong identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName(AccessibilityCustomActionNameDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionNameDelegate))]
-        private static string _UnityAX_CustomActionName(int identifier, int idx)
-#endif
+        private static string _UnityAX_CustomActionName(ulong identifier, int idx)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1213,17 +1083,10 @@ namespace Apple.Accessibility
             return null;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityPerformCustomActionDelegate2(ulong identifier, int idx);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformCustomAction2(AccessibilityPerformCustomActionDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate2))]
-        private static bool _UnityAX_PerformCustomAction2(ulong identifier, int idx)
-#else
-        private delegate bool AccessibilityPerformCustomActionDelegate(int identifier, int idx);
+        private delegate bool AccessibilityPerformCustomActionDelegate(ulong identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformCustomAction(AccessibilityPerformCustomActionDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
-        private static bool _UnityAX_PerformCustomAction(int identifier, int idx)
-#endif
+        private static bool _UnityAX_PerformCustomAction(ulong identifier, int idx)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1243,17 +1106,10 @@ namespace Apple.Accessibility
             return false;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityPerformMagicTapDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformMagicTap2(AccessibilityPerformMagicTapDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformMagicTapDelegate2))]
-        internal static bool _UnityAX_AccessibilityPerformMagicTap2(ulong identifier)
-#else
-        private delegate bool AccessibilityPerformMagicTapDelegate(int identifier);
+        private delegate bool AccessibilityPerformMagicTapDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformMagicTap(AccessibilityPerformMagicTapDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformMagicTapDelegate))]
-        internal static bool _UnityAX_AccessibilityPerformMagicTap(int identifier)
-#endif
+        internal static bool _UnityAX_AccessibilityPerformMagicTap(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1262,17 +1118,10 @@ namespace Apple.Accessibility
             return false;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityPerformEscapeDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformEscape2(AccessibilityPerformEscapeDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformEscapeDelegate2))]
-        internal static bool _UnityAX_AccessibilityPerformEscape2(ulong identifier)
-#else
-        private delegate bool AccessibilityPerformEscapeDelegate(int identifier);
+        private delegate bool AccessibilityPerformEscapeDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformEscape(AccessibilityPerformEscapeDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformEscapeDelegate))]
-        internal static bool _UnityAX_AccessibilityPerformEscape(int identifier)
-#endif
+        internal static bool _UnityAX_AccessibilityPerformEscape(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1281,17 +1130,10 @@ namespace Apple.Accessibility
             return false;
         }
 
-#if UNITY_6000_4_OR_NEWER
-        private delegate bool AccessibilityActivateDelegate2(ulong identifier);
-        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivate2(AccessibilityActivateDelegate2 actionDelegate);
-        [AOT.MonoPInvokeCallback(typeof(AccessibilityActivateDelegate2))]
-        private static bool _UnityAX_AccessibilityActivate2(ulong identifier)
-#else
-        private delegate bool AccessibilityActivateDelegate(int identifier);
+        private delegate bool AccessibilityActivateDelegate(ulong identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivate(AccessibilityActivateDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityActivateDelegate))]
-        private static bool _UnityAX_AccessibilityActivate(int identifier)
-#endif
+        private static bool _UnityAX_AccessibilityActivate(ulong identifier)
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/AccessibilityNode.cs
@@ -875,7 +875,28 @@ namespace Apple.Accessibility
             if (!__registered)
             {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-                _UnityAX_InitializeAXRuntime();
+#if UNITY_6000_4_OR_NEWER
+                _UnityAX_InitializeAXRuntime(2);
+                _UnityAX_registerAccessibilityFrame2(_UnityAX_accessibilityFrame2);
+                _UnityAX_registerAccessibilityLabel2(_UnityAX_accessibilityLabel2);
+                _UnityAX_registerAccessibilityTraits2(_UnityAX_accessibilityTraits2);
+                _UnityAX_registerAccessibilityIsElement2(_UnityAX_IsAccessibilityElement2);
+                _UnityAX_registerAccessibilityHint2(_UnityAX_AccessibilityHint2);
+                _UnityAX_registerAccessibilityValue2(_UnityAX_AccessibilityValue2);
+                _UnityAX_registerAccessibilityIdentifier2(_UnityAX_AccessibilityIdentifier2);
+                _UnityAX_registerAccessibilityViewIsModal2(_UnityAX_AccessibilityViewIsModal2);
+                _UnityAX_registerAccessibilityActivationPoint2(_UnityAX_AccessibilityActivationPoint2);
+                _UnityAX_registerAccessibilityPerformMagicTap2(_UnityAX_AccessibilityPerformMagicTap2);
+                _UnityAX_registerAccessibilityPerformEscape2(_UnityAX_AccessibilityPerformEscape2);
+                _UnityAX_registerAccessibilityActivate2(_UnityAX_AccessibilityActivate2);
+                _UnityAX_registerAccessibilityIncrement2(_UnityAX_AccessibilityIncrement2);
+                _UnityAX_registerAccessibilityDecrement2(_UnityAX_AccessibilityDecrement2);
+                _UnityAX_registerAccessibilityScroll2(_UnityAX_AccessibilityScroll2);
+                _UnityAX_registerAccessibilityCustomActionsCount2(_UnityAX_AccessibilityCustomActionCount2);
+                _UnityAX_registerAccessibilityPerformCustomAction2(_UnityAX_PerformCustomAction2);
+                _UnityAX_registerAccessibilityCustomActionName2(_UnityAX_CustomActionName2);
+#else
+                _UnityAX_InitializeAXRuntime(0);
                 _UnityAX_registerAccessibilityFrame(_UnityAX_accessibilityFrame);
                 _UnityAX_registerAccessibilityLabel(_UnityAX_accessibilityLabel);
                 _UnityAX_registerAccessibilityTraits(_UnityAX_accessibilityTraits);
@@ -895,21 +916,33 @@ namespace Apple.Accessibility
                 _UnityAX_registerAccessibilityPerformCustomAction(_UnityAX_PerformCustomAction);
                 _UnityAX_registerAccessibilityCustomActionName(_UnityAX_CustomActionName);
 #endif
+#endif
                 __registered = true;
             }
         }
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-        [DllImport("__Internal")] private static extern void _UnityAX_InitializeAXRuntime();
-        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier(int identifier, int parentIdentifier, bool hasParent);
+        // Parameter callbackOption tells native code which set of calbacks to use. Valid values: 0, 2
+        [DllImport("__Internal")] private static extern void _UnityAX_InitializeAXRuntime(int callbackOption);
+#if UNITY_6000_4_OR_NEWER
         [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier2(ulong identifier, ulong parentIdentifier, bool hasParent);
-        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier2(ulong identifier);
+#else
+        [DllImport("__Internal")] private static extern void _UnityAX_RegisterElementWithIdentifier(int identifier, int parentIdentifier, bool hasParent);
+        [DllImport("__Internal")] private static extern void _UnityAX_UnregisterElementWithIdentifier(int identifier);
+#endif
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityFrameDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityFrame2(AccessibilityFrameDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityFrameDelegate2))]
+        private static string _UnityAX_accessibilityFrame2(ulong identifier)
+#else
         private delegate string AccessibilityFrameDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityFrame(AccessibilityFrameDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityFrameDelegate))]
         private static string _UnityAX_accessibilityFrame(int identifier)
+#endif
         {
             Rect rect = Rect.zero;
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
@@ -919,10 +952,17 @@ namespace Apple.Accessibility
             return _stringForRect(rect);
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityLabelDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityLabel2(AccessibilityLabelDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityLabelDelegate2))]
+        private static string _UnityAX_accessibilityLabel2(ulong identifier)
+#else
         private delegate string AccessibilityLabelDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityLabel(AccessibilityLabelDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityLabelDelegate))]
         private static string _UnityAX_accessibilityLabel(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -931,10 +971,17 @@ namespace Apple.Accessibility
             return null;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate ulong AccessibilityTraitsDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityTraits2(AccessibilityTraitsDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityTraitsDelegate2))]
+        private static ulong _UnityAX_accessibilityTraits2(ulong identifier)
+#else
         private delegate ulong AccessibilityTraitsDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityTraits(AccessibilityTraitsDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityTraitsDelegate))]
         private static ulong _UnityAX_accessibilityTraits(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -943,10 +990,17 @@ namespace Apple.Accessibility
             return 0;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool IsAccessibilityElementDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIsElement2(IsAccessibilityElementDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(IsAccessibilityElementDelegate2))]
+        private static bool _UnityAX_IsAccessibilityElement2(ulong identifier)
+#else
         private delegate bool IsAccessibilityElementDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIsElement(IsAccessibilityElementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(IsAccessibilityElementDelegate))]
         private static bool _UnityAX_IsAccessibilityElement(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -955,10 +1009,17 @@ namespace Apple.Accessibility
             return true;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityHintDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityHint2(AccessibilityHintDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityHintDelegate2))]
+        private static string _UnityAX_AccessibilityHint2(ulong identifier)
+#else
         private delegate string AccessibilityHintDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityHint(AccessibilityHintDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityHintDelegate))]
         private static string _UnityAX_AccessibilityHint(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -967,10 +1028,17 @@ namespace Apple.Accessibility
             return null;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityValueDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityValue2(AccessibilityValueDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityValueDelegate2))]
+        private static string _UnityAX_AccessibilityValue2(ulong identifier)
+#else
         private delegate string AccessibilityValueDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityValue(AccessibilityValueDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityValueDelegate))]
         private static string _UnityAX_AccessibilityValue(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -979,10 +1047,17 @@ namespace Apple.Accessibility
             return null;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityIdentifierDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIdentifier2(AccessibilityIdentifierDelegate2 identifierDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityIdentifierDelegate2))]
+        private static string _UnityAX_AccessibilityIdentifier2(ulong identifier)
+#else
         private delegate string AccessibilityIdentifierDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIdentifier(AccessibilityIdentifierDelegate identifierDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityIdentifierDelegate))]
         private static string _UnityAX_AccessibilityIdentifier(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -991,10 +1066,17 @@ namespace Apple.Accessibility
             return null;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityViewIsModalDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityViewIsModal2(AccessibilityViewIsModalDelegate2 viewIsModalDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityViewIsModalDelegate2))]
+        private static bool _UnityAX_AccessibilityViewIsModal2(ulong identifier)
+#else
         private delegate bool AccessibilityViewIsModalDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityViewIsModal(AccessibilityViewIsModalDelegate viewIsModalDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityViewIsModalDelegate))]
         private static bool _UnityAX_AccessibilityViewIsModal(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1003,10 +1085,17 @@ namespace Apple.Accessibility
             return false;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityActivationPointDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivationPoint2(AccessibilityActivationPointDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityActivationPointDelegate2))]
+        private static string _UnityAX_AccessibilityActivationPoint2(ulong identifier)
+#else
         private delegate string AccessibilityActivationPointDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivationPoint(AccessibilityActivationPointDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityActivationPointDelegate))]
         private static string _UnityAX_AccessibilityActivationPoint(int identifier)
+#endif
         {
             Vector2 value = Vector2.positiveInfinity;
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
@@ -1016,10 +1105,17 @@ namespace Apple.Accessibility
             return value == Vector2.positiveInfinity ? null : _stringForPoint(value);
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityScrollDelegate2(ulong identifier, int direction);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityScroll2(AccessibilityScrollDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityScrollDelegate2))]
+        private static bool _UnityAX_AccessibilityScroll2(ulong identifier, int direction)
+#else
         private delegate bool AccessibilityScrollDelegate(int identifier, int direction);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityScroll(AccessibilityScrollDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityScrollDelegate))]
         private static bool _UnityAX_AccessibilityScroll(int identifier, int direction)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1028,10 +1124,17 @@ namespace Apple.Accessibility
             return false;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate void AccessibilityIncrementDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIncrement2(AccessibilityIncrementDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityIncrementDelegate2))]
+        private static void _UnityAX_AccessibilityIncrement2(ulong identifier)
+#else
         private delegate void AccessibilityIncrementDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityIncrement(AccessibilityIncrementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityIncrementDelegate))]
         private static void _UnityAX_AccessibilityIncrement(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1039,10 +1142,17 @@ namespace Apple.Accessibility
             }
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate void AccessibilityDecrementDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityDecrement2(AccessibilityDecrementDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityDecrementDelegate2))]
+        private static void _UnityAX_AccessibilityDecrement2(ulong identifier)
+#else
         private delegate void AccessibilityDecrementDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityDecrement(AccessibilityDecrementDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityDecrementDelegate))]
         private static void _UnityAX_AccessibilityDecrement(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1050,10 +1160,17 @@ namespace Apple.Accessibility
             }
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate ulong AccessibilityCustomActionsCountDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionsCount2(AccessibilityCustomActionsCountDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionsCountDelegate2))]
+        private static ulong _UnityAX_AccessibilityCustomActionCount2(ulong identifier)
+#else
         private delegate ulong AccessibilityCustomActionsCountDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionsCount(AccessibilityCustomActionsCountDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityCustomActionsCountDelegate))]
         private static ulong _UnityAX_AccessibilityCustomActionCount(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1066,10 +1183,17 @@ namespace Apple.Accessibility
             return 0;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate string AccessibilityCustomActionNameDelegate2(ulong identifier, int idx);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName2(AccessibilityCustomActionNameDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
+        private static string _UnityAX_CustomActionName2(ulong identifier, int idx)
+#else
         private delegate string AccessibilityCustomActionNameDelegate(int identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityCustomActionName(AccessibilityCustomActionNameDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
         private static string _UnityAX_CustomActionName(int identifier, int idx)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1089,10 +1213,17 @@ namespace Apple.Accessibility
             return null;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityPerformCustomActionDelegate2(ulong identifier, int idx);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformCustomAction2(AccessibilityPerformCustomActionDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate2))]
+        private static bool _UnityAX_PerformCustomAction2(ulong identifier, int idx)
+#else
         private delegate bool AccessibilityPerformCustomActionDelegate(int identifier, int idx);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformCustomAction(AccessibilityPerformCustomActionDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformCustomActionDelegate))]
         private static bool _UnityAX_PerformCustomAction(int identifier, int idx)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1112,10 +1243,17 @@ namespace Apple.Accessibility
             return false;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityPerformMagicTapDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformMagicTap2(AccessibilityPerformMagicTapDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformMagicTapDelegate2))]
+        internal static bool _UnityAX_AccessibilityPerformMagicTap2(ulong identifier)
+#else
         private delegate bool AccessibilityPerformMagicTapDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformMagicTap(AccessibilityPerformMagicTapDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformMagicTapDelegate))]
         internal static bool _UnityAX_AccessibilityPerformMagicTap(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1124,10 +1262,17 @@ namespace Apple.Accessibility
             return false;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityPerformEscapeDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformEscape2(AccessibilityPerformEscapeDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformEscapeDelegate2))]
+        internal static bool _UnityAX_AccessibilityPerformEscape2(ulong identifier)
+#else
         private delegate bool AccessibilityPerformEscapeDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityPerformEscape(AccessibilityPerformEscapeDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityPerformEscapeDelegate))]
         internal static bool _UnityAX_AccessibilityPerformEscape(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {
@@ -1136,10 +1281,17 @@ namespace Apple.Accessibility
             return false;
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private delegate bool AccessibilityActivateDelegate2(ulong identifier);
+        [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivate2(AccessibilityActivateDelegate2 actionDelegate);
+        [AOT.MonoPInvokeCallback(typeof(AccessibilityActivateDelegate2))]
+        private static bool _UnityAX_AccessibilityActivate2(ulong identifier)
+#else
         private delegate bool AccessibilityActivateDelegate(int identifier);
         [DllImport("__Internal")] private static extern void _UnityAX_registerAccessibilityActivate(AccessibilityActivateDelegate actionDelegate);
         [AOT.MonoPInvokeCallback(typeof(AccessibilityActivateDelegate))]
         private static bool _UnityAX_AccessibilityActivate(int identifier)
+#endif
         {
             if (axElements.TryGetValue(identifier, out AccessibilityNode obj))
             {

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityNode_TestSuite.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityNode_TestSuite.cs
@@ -61,7 +61,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityLabel", "Button");
 #else
-            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityLabel", "Button");
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult((ulong)axObject.gameObject.GetInstanceID(), "accessibilityLabel", "Button");
 #endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
@@ -82,7 +82,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityValue", "ButtonValue");
 #else
-            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityValue", "ButtonValue");
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult((ulong)axObject.gameObject.GetInstanceID(), "accessibilityValue", "ButtonValue");
 #endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
@@ -103,7 +103,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityHint", "ButtonHint");
 #else
-            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityHint", "ButtonHint");
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult((ulong)axObject.gameObject.GetInstanceID(), "accessibilityHint", "ButtonHint");
 #endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
@@ -150,7 +150,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap((ulong)axObject.gameObject.GetInstanceID());
 #endif
             expectedMagicTapCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
@@ -175,7 +175,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap((ulong)axObject.gameObject.GetInstanceID());
 #endif
             expectedMagicTapCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
@@ -192,10 +192,9 @@ namespace Apple.Accessibility.UnitTests
             axObject.onAccessibilityPerformMagicTap = null;
 
 #if UNITY_6000_4_OR_NEWER
-            EntityId.ToULong(axObject.gameObject.GetEntityId())
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap((ulong)axObject.gameObject.GetInstanceID());
 #endif
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);
@@ -233,7 +232,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape((ulong)axObject.gameObject.GetInstanceID());
 #endif
             expectedEscapeCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
@@ -258,7 +257,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape((ulong)axObject.gameObject.GetInstanceID());
 #endif
             expectedEscapeCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
@@ -277,7 +276,7 @@ namespace Apple.Accessibility.UnitTests
 #if UNITY_6000_4_OR_NEWER
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
 #else
-            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape((ulong)axObject.gameObject.GetInstanceID());
 #endif
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityNode_TestSuite.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityNode_TestSuite.cs
@@ -58,7 +58,11 @@ namespace Apple.Accessibility.UnitTests
             AccessibilityNode axObject = ButtonAXObject();
             UnityEngine.Assertions.Assert.AreEqual(axObject.AccessibilityLabel, "Button");
 
+#if UNITY_6000_4_OR_NEWER
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityLabel", "Button");
+#else
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityLabel", "Button");
+#endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
             yield return null;
@@ -75,7 +79,11 @@ namespace Apple.Accessibility.UnitTests
             AccessibilityNode axObject = ButtonAXObject();
             UnityEngine.Assertions.Assert.AreEqual(axObject.AccessibilityValue, "ButtonValue");
 
+#if UNITY_6000_4_OR_NEWER
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityValue", "ButtonValue");
+#else
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityValue", "ButtonValue");
+#endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
             yield return null;
@@ -92,7 +100,11 @@ namespace Apple.Accessibility.UnitTests
             AccessibilityNode axObject = ButtonAXObject();
             UnityEngine.Assertions.Assert.AreEqual(axObject.AccessibilityHint, "ButtonHint");
 
+#if UNITY_6000_4_OR_NEWER
+            bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(EntityId.ToULong(axObject.gameObject.GetEntityId()), "accessibilityHint", "ButtonHint");
+#else
             bool succeeded = AccessibilityTests.RuniOSSideUnitTestWithKeyPathExpectingStringResult(axObject.gameObject.GetInstanceID(), "accessibilityHint", "ButtonHint");
+#endif
             UnityEngine.Assertions.Assert.IsTrue(succeeded);
 
             yield return null;
@@ -135,7 +147,11 @@ namespace Apple.Accessibility.UnitTests
                 return true;
             };
 
+#if UNITY_6000_4_OR_NEWER
+            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+#endif
             expectedMagicTapCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
             UnityEngine.Assertions.Assert.IsTrue(tapSucceeded);
@@ -156,7 +172,11 @@ namespace Apple.Accessibility.UnitTests
                 return false;
             };
 
+#if UNITY_6000_4_OR_NEWER
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+#endif
             expectedMagicTapCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);
@@ -171,7 +191,12 @@ namespace Apple.Accessibility.UnitTests
             //Unimplemented tap
             axObject.onAccessibilityPerformMagicTap = null;
 
+#if UNITY_6000_4_OR_NEWER
+            EntityId.ToULong(axObject.gameObject.GetEntityId())
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformMagicTap(axObject.gameObject.GetInstanceID());
+#endif
             UnityEngine.Assertions.Assert.AreEqual(magicTapCount, expectedMagicTapCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);
 #if UNITY_IOS && !UNITY_EDITOR
@@ -205,7 +230,11 @@ namespace Apple.Accessibility.UnitTests
                 return true;
             };
 
+#if UNITY_6000_4_OR_NEWER
+            bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             bool tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+#endif
             expectedEscapeCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
             UnityEngine.Assertions.Assert.IsTrue(tapSucceeded);
@@ -226,7 +255,11 @@ namespace Apple.Accessibility.UnitTests
                 return false;
             };
 
+#if UNITY_6000_4_OR_NEWER
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+#endif
             expectedEscapeCount += 1;
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);
@@ -241,7 +274,11 @@ namespace Apple.Accessibility.UnitTests
             //Unimplemented tap
             axObject.onAccessibilityPerformEscape = null;
 
+#if UNITY_6000_4_OR_NEWER
+            tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(EntityId.ToULong(axObject.gameObject.GetEntityId()));
+#else
             tapSucceeded = AccessibilityRuntime._UnityAX_AccessibilityPerformEscape(axObject.gameObject.GetInstanceID());
+#endif
             UnityEngine.Assertions.Assert.AreEqual(EscapeCount, expectedEscapeCount);
             UnityEngine.Assertions.Assert.IsFalse(tapSucceeded);
 #if UNITY_IOS && !UNITY_EDITOR

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
@@ -8,13 +8,8 @@ namespace Apple.Accessibility.UnitTests
         [DllImport("__Internal")]
         private static extern bool _UnityAX_RuniOSSideUnitTestWithName(string name);
 
-#if UNITY_6000_4_OR_NEWER
         [DllImport("__Internal")]
-        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(ulong identifier, string keyPath, string expected);
-#else
-        [DllImport("__Internal")]
-        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected);
-#endif
+        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(ulong identifier, string keyPath, string expected);
 
         public static bool RuniOSUnitTestWithName(string name)
         {
@@ -25,25 +20,14 @@ namespace Apple.Accessibility.UnitTests
 #endif
         }
 
-#if UNITY_6000_4_OR_NEWER
         public static bool RuniOSSideUnitTestWithKeyPathExpectingStringResult(ulong identifier, string keyPath, string expected)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(identifier, keyPath, expected);
+            return _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(identifier, keyPath, expected);
 #else
             return true;
 #endif
         }
-#else
-        public static bool RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected)
-        {
-#if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult( identifier, keyPath, expected);
-#else
-            return true;
-#endif
-        }
-#endif
 
         [DllImport("__Internal")]
         private static extern void _UnityAX_PostFeatureEnabledNotification(string name, bool enabled);

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
@@ -8,11 +8,13 @@ namespace Apple.Accessibility.UnitTests
         [DllImport("__Internal")]
         private static extern bool _UnityAX_RuniOSSideUnitTestWithName(string name);
 
-        [DllImport("__Internal")]
-        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected);
-
+#if UNITY_6000_4_OR_NEWER
         [DllImport("__Internal")]
         private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(ulong identifier, string keyPath, string expected);
+#else
+        [DllImport("__Internal")]
+        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected);
+#endif
 
         public static bool RuniOSUnitTestWithName(string name)
         {

--- a/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
+++ b/plug-ins/Apple.Accessibility/Apple.Accessibility_Unity/Assets/Apple.Accessibility/Tests/AccessibilityTests/AccessibilityTests.cs
@@ -11,6 +11,8 @@ namespace Apple.Accessibility.UnitTests
         [DllImport("__Internal")]
         private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected);
 
+        [DllImport("__Internal")]
+        private static extern bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(ulong identifier, string keyPath, string expected);
 
         public static bool RuniOSUnitTestWithName(string name)
         {
@@ -21,6 +23,16 @@ namespace Apple.Accessibility.UnitTests
 #endif
         }
 
+#if UNITY_6000_4_OR_NEWER
+        public static bool RuniOSSideUnitTestWithKeyPathExpectingStringResult(ulong identifier, string keyPath, string expected)
+        {
+#if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+            return _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(identifier, keyPath, expected);
+#else
+            return true;
+#endif
+        }
+#else
         public static bool RuniOSSideUnitTestWithKeyPathExpectingStringResult(int identifier, string keyPath, string expected)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
@@ -29,6 +41,7 @@ namespace Apple.Accessibility.UnitTests
             return true;
 #endif
         }
+#endif
 
         [DllImport("__Internal")]
         private static extern void _UnityAX_PostFeatureEnabledNotification(string name, bool enabled);

--- a/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
+++ b/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
@@ -42,77 +42,130 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_PostPageScrolledNotification(const char
 #pragma mark Elements
 
 typedef char *(* AccessibilityFrameDelegate)(int32_t);
+typedef char *(* AccessibilityFrameDelegate2)(uint64_t);
 static AccessibilityFrameDelegate __axFrameDelegate = NULL;
+static AccessibilityFrameDelegate2 __axFrameDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityFrame(AccessibilityFrameDelegate delegate) { __axFrameDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityFrame2(AccessibilityFrameDelegate2 delegate) { __axFrameDelegate2 = delegate; }
 
 typedef char *(* AccessibilityLabelDelegate)(int32_t);
+typedef char *(* AccessibilityLabelDelegate2)(uint64_t);
 static AccessibilityLabelDelegate __axLabelDelegate = NULL;
+static AccessibilityLabelDelegate2 __axLabelDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityLabel(AccessibilityLabelDelegate delegate) { __axLabelDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityLabel2(AccessibilityLabelDelegate2 delegate) { __axLabelDelegate2 = delegate; }
 
 typedef uint64_t (* AccessibilityTraitsDelegate)(int32_t);
+typedef uint64_t (* AccessibilityTraitsDelegate2)(uint64_t);
 static AccessibilityTraitsDelegate __axTraitsDelegate = NULL;
+static AccessibilityTraitsDelegate2 __axTraitsDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityTraits(AccessibilityTraitsDelegate delegate) { __axTraitsDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityTraits2(AccessibilityTraitsDelegate2 delegate) { __axTraitsDelegate2 = delegate; }
 
 typedef bool (* AccessibilityIsElementDelegate)(int32_t);
+typedef bool (* AccessibilityIsElementDelegate2)(uint64_t);
 static AccessibilityIsElementDelegate __axIsElementDelegate = NULL;
+static AccessibilityIsElementDelegate2 __axIsElementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIsElement(AccessibilityIsElementDelegate delegate) { __axIsElementDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIsElement2(AccessibilityIsElementDelegate2 delegate) { __axIsElementDelegate2 = delegate; }
 
 typedef char *(* AccessibilityHintDelegate)(int32_t);
+typedef char *(* AccessibilityHintDelegate2)(uint64_t);
 static AccessibilityHintDelegate __axHintDelegate = NULL;
+static AccessibilityHintDelegate2 __axHintDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityHint(AccessibilityHintDelegate delegate) { __axHintDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityHint2(AccessibilityHintDelegate2 delegate) { __axHintDelegate2 = delegate; }
 
 typedef char *(* AccessibilityValueDelegate)(int32_t);
+typedef char *(* AccessibilityValueDelegate2)(uint64_t);
 static AccessibilityValueDelegate __axValueDelegate = NULL;
+static AccessibilityValueDelegate2 __axValueDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityValue(AccessibilityValueDelegate delegate) { __axValueDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityValue2(AccessibilityValueDelegate2 delegate) { __axValueDelegate2 = delegate; }
 
 typedef char *(* AccessibilityIdentifierDelegate)(int32_t);
+typedef char *(* AccessibilityIdentifierDelegate2)(uint64_t);
 static AccessibilityIdentifierDelegate __axIdentifierDelegate = NULL;
+static AccessibilityIdentifierDelegate2 __axIdentifierDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIdentifier(AccessibilityIdentifierDelegate delegate) { __axIdentifierDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIdentifier2(AccessibilityIdentifierDelegate2 delegate) { __axIdentifierDelegate2 = delegate; }
 
 typedef bool (* AccessibilityViewIsModalDelegate)(int32_t);
+typedef bool (* AccessibilityViewIsModalDelegate2)(uint64_t);
 static AccessibilityViewIsModalDelegate __axViewIsModalDelegate = NULL;
+static AccessibilityViewIsModalDelegate2 __axViewIsModalDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityViewIsModal(AccessibilityViewIsModalDelegate delegate) { __axViewIsModalDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityViewIsModal2(AccessibilityViewIsModalDelegate2 delegate) { __axViewIsModalDelegate2 = delegate; }
 
 typedef char *(* AccessibilityActivationPointDelegate)(int32_t);
+typedef char *(* AccessibilityActivationPointDelegate2)(uint64_t);
 static AccessibilityActivationPointDelegate __axActivationPointDelegate = NULL;
+static AccessibilityActivationPointDelegate2 __axActivationPointDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivationPoint(AccessibilityActivationPointDelegate delegate) { __axActivationPointDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivationPoint2(AccessibilityActivationPointDelegate2 delegate) { __axActivationPointDelegate2 = delegate; }
 
 typedef uint64_t (* AccessibilityCustomActionsCountDelegate)(int32_t);
+typedef uint64_t (* AccessibilityCustomActionsCountDelegate2)(uint64_t);
 static AccessibilityCustomActionsCountDelegate __axCustomActionsCountDelegate = NULL;
+static AccessibilityCustomActionsCountDelegate2 __axCustomActionsCountDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionsCount(AccessibilityCustomActionsCountDelegate delegate) { __axCustomActionsCountDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionsCount2(AccessibilityCustomActionsCountDelegate2 delegate) { __axCustomActionsCountDelegate2 = delegate; }
 
 typedef bool (* AccessibilityPerformCustomActionDelegate)(int32_t, int32_t);
+typedef bool (* AccessibilityPerformCustomActionDelegate2)(uint64_t, int32_t);
 static AccessibilityPerformCustomActionDelegate __axPerformCustomActionDelegate = NULL;
+static AccessibilityPerformCustomActionDelegate2 __axPerformCustomActionDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformCustomAction(AccessibilityPerformCustomActionDelegate delegate) { __axPerformCustomActionDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformCustomAction2(AccessibilityPerformCustomActionDelegate2 delegate) { __axPerformCustomActionDelegate2 = delegate; }
 
 typedef char *(* AccessibilityCustomActionNameDelegate)(int32_t, int32_t);
+typedef char *(* AccessibilityCustomActionNameDelegate2)(uint64_t, int32_t);
 static AccessibilityCustomActionNameDelegate __axCustomActionNameDelegate = NULL;
+static AccessibilityCustomActionNameDelegate2 __axCustomActionNameDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionName(AccessibilityCustomActionNameDelegate delegate) { __axCustomActionNameDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionName2(AccessibilityCustomActionNameDelegate2 delegate) { __axCustomActionNameDelegate2 = delegate; }
 
 typedef bool (* AccessibilityScrollDelegate)(int32_t, uint32_t);
+typedef bool (* AccessibilityScrollDelegate2)(uint64_t, uint32_t);
 static AccessibilityScrollDelegate __axScrollDelegate = NULL;
+static AccessibilityScrollDelegate2 __axScrollDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityScroll(AccessibilityScrollDelegate delegate) { __axScrollDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityScroll2(AccessibilityScrollDelegate2 delegate) { __axScrollDelegate2 = delegate; }
 
 typedef bool (* AccessibilityPerformMagicTapDelegate)(int32_t);
+typedef bool (* AccessibilityPerformMagicTapDelegate2)(uint64_t);
 static AccessibilityPerformMagicTapDelegate __axPerformMagicTapDelegate = NULL;
+static AccessibilityPerformMagicTapDelegate2 __axPerformMagicTapDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformMagicTap(AccessibilityPerformMagicTapDelegate delegate) { __axPerformMagicTapDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformMagicTap2(AccessibilityPerformMagicTapDelegate2 delegate) { __axPerformMagicTapDelegate2 = delegate; }
 
 typedef bool (* AccessibilityPerformEscapeDelegate)(int32_t);
+typedef bool (* AccessibilityPerformEscapeDelegate2)(uint64_t);
 static AccessibilityPerformEscapeDelegate __axPerformEscapeDelegate = NULL;
+static AccessibilityPerformEscapeDelegate2 __axPerformEscapeDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformEscape(AccessibilityPerformEscapeDelegate delegate) { __axPerformEscapeDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformEscape2(AccessibilityPerformEscapeDelegate2 delegate) { __axPerformEscapeDelegate2 = delegate; }
 
 typedef bool (* AccessibilityActivateDelegate)(int32_t);
+typedef bool (* AccessibilityActivateDelegate2)(uint64_t);
 static AccessibilityActivateDelegate __axActivateDelegate = NULL;
+static AccessibilityActivateDelegate2 __axActivateDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivate(AccessibilityActivateDelegate delegate) { __axActivateDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivate2(AccessibilityActivateDelegate2 delegate) { __axActivateDelegate2 = delegate; }
 
 typedef void (* AccessibilityIncrementDelegate)(int32_t);
+typedef void (* AccessibilityIncrementDelegate2)(uint64_t);
 static AccessibilityIncrementDelegate __axIncrementDelegate = NULL;
+static AccessibilityIncrementDelegate2 __axIncrementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIncrement(AccessibilityIncrementDelegate delegate) { __axIncrementDelegate = delegate; }
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIncrement2(AccessibilityIncrementDelegate2 delegate) { __axIncrementDelegate2 = delegate; }
 
 typedef void (* AccessibilityDecrementDelegate)(int32_t);
+typedef void (* AccessibilityDecrementDelegate2)(uint64_t);
 static AccessibilityDecrementDelegate __axDecrementDelegate = NULL;
+static AccessibilityDecrementDelegate2 __axDecrementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityDecrement(AccessibilityDecrementDelegate delegate) { __axDecrementDelegate = delegate; }
-
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityDecrement2(AccessibilityDecrementDelegate2 delegate) { __axDecrementDelegate2 = delegate; }
 
 #pragma mark Settings
 
@@ -553,7 +606,8 @@ APPLE_ACCESSIBILITY_HIDDEN
 
 static _AppleAccessibilityNotificationObserver *_observer;
 
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(void)
+// The callbackOption parameter represents a hint from Unity about which set of callbacks to use.
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(int32_t callbackOption)
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -602,139 +656,278 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(void)
             [center addObserver:_observer selector:@selector(_accessibilityStatusChangedCallback:) name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification object:nil];
         }
 
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
-            if ( __axFrameDelegate == NULL )
-            {
-                return CGRectZero;
-            }
-            char *rectStr = __axFrameDelegate((int32_t)identifier.integerValue);
-            return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
-            if ( __axLabelDelegate == NULL )
-            {
-                return nil;
-            }
-            char *str = __axLabelDelegate((int32_t)identifier.integerValue);
-            return str == NULL ? nil : [NSString stringWithUTF8String:str];
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
-            if ( __axTraitsDelegate == NULL )
-            {
-                return (uint64_t)0;
-            }
-            return __axTraitsDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
-            if ( __axCustomActionsCountDelegate == NULL )
-            {
-                return (uint64_t)0;
-            }
-            return __axCustomActionsCountDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
-            if ( __axPerformCustomActionDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axPerformCustomActionDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
-            if ( __axCustomActionNameDelegate == NULL )
-            {
-                return nil;
-            }
-            char *str = __axCustomActionNameDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
-            return str == NULL ? nil : [NSString stringWithUTF8String:str];
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
-            if ( __axIsElementDelegate == NULL )
-            {
-                return YES;
-            }
-            return __axIsElementDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
-            if ( __axHintDelegate == NULL )
-            {
-                return nil;
-            }
-            char *str = __axHintDelegate((int32_t)identifier.integerValue);
-            return str == NULL ? nil : [NSString stringWithUTF8String:str];
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
-            if ( __axValueDelegate == NULL )
-            {
-                return nil;
-            }
-            char *str = __axValueDelegate((int32_t)identifier.integerValue);
-            return str == NULL ? nil : [NSString stringWithUTF8String:str];
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
-            if ( __axActivationPointDelegate == NULL )
-            {
-                return kAXCenterPointDefaultPoint;
-            }
-            char *pointStr = __axActivationPointDelegate((int32_t)identifier.integerValue);
-            return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
-            if ( __axIdentifierDelegate == NULL )
-            {
-                return nil;
-            }
-            char *str = __axIdentifierDelegate((int32_t)identifier.integerValue);
-            return str == NULL ? nil : [NSString stringWithUTF8String:str];
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
-            if ( __axViewIsModalDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axViewIsModalDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
-            if ( __axScrollDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axScrollDelegate((int32_t)identifier.integerValue, (int32_t)direction);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
-            if ( __axPerformMagicTapDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axPerformMagicTapDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
-            if ( __axPerformEscapeDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axPerformEscapeDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
-            if ( __axActivateDelegate == NULL )
-            {
-                return NO;
-            }
-            return __axActivateDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
-            if ( __axIncrementDelegate == NULL )
-            {
-                return;
-            }
-            __axIncrementDelegate((int32_t)identifier.integerValue);
-        }];
-        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
-            if ( __axDecrementDelegate == NULL )
-            {
-                return;
-            }
-            __axDecrementDelegate((int32_t)identifier.integerValue);
-        }];
+        if (callbackOption == 0)
+        {
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
+                if ( __axFrameDelegate == NULL )
+                {
+                    return CGRectZero;
+                }
+                char *rectStr = __axFrameDelegate((int32_t)identifier.integerValue);
+                return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
+                if ( __axLabelDelegate == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axLabelDelegate((int32_t)identifier.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
+                if ( __axTraitsDelegate == NULL )
+                {
+                    return (uint64_t)0;
+                }
+                return __axTraitsDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
+                if ( __axIsElementDelegate == NULL )
+                {
+                    return YES;
+                }
+                return __axIsElementDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
+                if ( __axHintDelegate == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axHintDelegate((int32_t)identifier.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
+                if ( __axValueDelegate == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axValueDelegate((int32_t)identifier.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
+                if ( __axIdentifierDelegate == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axIdentifierDelegate((int32_t)identifier.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
+                if ( __axViewIsModalDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axViewIsModalDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
+                if ( __axActivationPointDelegate == NULL )
+                {
+                    return kAXCenterPointDefaultPoint;
+                }
+                char *pointStr = __axActivationPointDelegate((int32_t)identifier.integerValue);
+                return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
+                if ( __axCustomActionsCountDelegate == NULL )
+                {
+                    return (uint64_t)0;
+                }
+                return __axCustomActionsCountDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
+                if ( __axPerformCustomActionDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformCustomActionDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
+                if ( __axCustomActionNameDelegate == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axCustomActionNameDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
+                if ( __axScrollDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axScrollDelegate((int32_t)identifier.integerValue, (int32_t)direction);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
+                if ( __axPerformMagicTapDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformMagicTapDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
+                if ( __axPerformEscapeDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformEscapeDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
+                if ( __axActivateDelegate == NULL )
+                {
+                    return NO;
+                }
+                return __axActivateDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
+                if ( __axIncrementDelegate == NULL )
+                {
+                    return;
+                }
+                __axIncrementDelegate((int32_t)identifier.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
+                if ( __axDecrementDelegate == NULL )
+                {
+                    return;
+                }
+                __axDecrementDelegate((int32_t)identifier.integerValue);
+            }];
+        }
+        else if (callbackOption == 2)
+        {
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
+                if ( __axFrameDelegate2 == NULL )
+                {
+                    return CGRectZero;
+                }
+                char *rectStr = __axFrameDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
+                if ( __axLabelDelegate2 == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axLabelDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
+                if ( __axTraitsDelegate2 == NULL )
+                {
+                    return (uint64_t)0;
+                }
+                return __axTraitsDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
+                if ( __axIsElementDelegate2 == NULL )
+                {
+                    return YES;
+                }
+                return __axIsElementDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
+                if ( __axHintDelegate2 == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axHintDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
+                if ( __axValueDelegate2 == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axValueDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
+                if ( __axIdentifierDelegate2 == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axIdentifierDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
+                if ( __axViewIsModalDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axViewIsModalDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
+                if ( __axActivationPointDelegate2 == NULL )
+                {
+                    return kAXCenterPointDefaultPoint;
+                }
+                char *pointStr = __axActivationPointDelegate2((uint64_t)identifier.unsignedLongLongValue);
+                return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
+                if ( __axCustomActionsCountDelegate2 == NULL )
+                {
+                    return (uint64_t)0;
+                }
+                return __axCustomActionsCountDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
+                if ( __axPerformCustomActionDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformCustomActionDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
+                if ( __axCustomActionNameDelegate2 == NULL )
+                {
+                    return nil;
+                }
+                char *str = __axCustomActionNameDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
+                return str == NULL ? nil : [NSString stringWithUTF8String:str];
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
+                if ( __axScrollDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axScrollDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)direction);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
+                if ( __axPerformMagicTapDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformMagicTapDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
+                if ( __axPerformEscapeDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axPerformEscapeDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
+                if ( __axActivateDelegate2 == NULL )
+                {
+                    return NO;
+                }
+                return __axActivateDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
+                if ( __axIncrementDelegate2 == NULL )
+                {
+                    return;
+                }
+                __axIncrementDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
+                if ( __axDecrementDelegate2 == NULL )
+                {
+                    return;
+                }
+                __axDecrementDelegate2((uint64_t)identifier.unsignedLongLongValue);
+            }];
+        }
     });
 }
 

--- a/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
+++ b/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
@@ -748,7 +748,17 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_RegisterElementWithIdentifier(int32_t i
     [AppleAccessibilityRuntime.sharedInstance registerAccessibilityElementWithIdentifier:@(identifier) parent: hasParent ? @(parentIdentifier) : nil hasParent:hasParent];
 }
 
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_RegisterElementWithIdentifier2(uint64_t identifier, uint64_t parentIdentifier, bool hasParent)
+{
+    [AppleAccessibilityRuntime.sharedInstance registerAccessibilityElementWithIdentifier:@(identifier) parent: hasParent ? @(parentIdentifier) : nil hasParent:hasParent];
+}
+
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_UnregisterElementWithIdentifier(int32_t identifier)
+{
+    [AppleAccessibilityRuntime.sharedInstance unregisterAccessibilityElementWithIdentifier:@(identifier)];
+}
+
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_UnregisterElementWithIdentifier2(uint64_t identifier)
 {
     [AppleAccessibilityRuntime.sharedInstance unregisterAccessibilityElementWithIdentifier:@(identifier)];
 }
@@ -759,6 +769,11 @@ APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithName(const char *
 }
 
 APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int32_t identifier, const char *keyPath, const char *expected)
+{
+    return [AppleAccessibilityRuntime.sharedInstance runUnitTestForIdentifier:@(identifier) keyPath:[NSString stringWithUTF8String:keyPath] expected:[NSString stringWithUTF8String:expected]];
+}
+
+APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(uint64_t identifier, const char *keyPath, const char *expected)
 {
     return [AppleAccessibilityRuntime.sharedInstance runUnitTestForIdentifier:@(identifier) keyPath:[NSString stringWithUTF8String:keyPath] expected:[NSString stringWithUTF8String:expected]];
 }

--- a/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
+++ b/plug-ins/Apple.Accessibility/Native/AppleAccessibility/AppleAccessibilityBridge.m
@@ -41,131 +41,77 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_PostPageScrolledNotification(const char
 
 #pragma mark Elements
 
-typedef char *(* AccessibilityFrameDelegate)(int32_t);
-typedef char *(* AccessibilityFrameDelegate2)(uint64_t);
+typedef char *(* AccessibilityFrameDelegate)(uint64_t);
 static AccessibilityFrameDelegate __axFrameDelegate = NULL;
-static AccessibilityFrameDelegate2 __axFrameDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityFrame(AccessibilityFrameDelegate delegate) { __axFrameDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityFrame2(AccessibilityFrameDelegate2 delegate) { __axFrameDelegate2 = delegate; }
 
-typedef char *(* AccessibilityLabelDelegate)(int32_t);
-typedef char *(* AccessibilityLabelDelegate2)(uint64_t);
+typedef char *(* AccessibilityLabelDelegate)(uint64_t);
 static AccessibilityLabelDelegate __axLabelDelegate = NULL;
-static AccessibilityLabelDelegate2 __axLabelDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityLabel(AccessibilityLabelDelegate delegate) { __axLabelDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityLabel2(AccessibilityLabelDelegate2 delegate) { __axLabelDelegate2 = delegate; }
 
-typedef uint64_t (* AccessibilityTraitsDelegate)(int32_t);
-typedef uint64_t (* AccessibilityTraitsDelegate2)(uint64_t);
+typedef uint64_t (* AccessibilityTraitsDelegate)(uint64_t);
 static AccessibilityTraitsDelegate __axTraitsDelegate = NULL;
-static AccessibilityTraitsDelegate2 __axTraitsDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityTraits(AccessibilityTraitsDelegate delegate) { __axTraitsDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityTraits2(AccessibilityTraitsDelegate2 delegate) { __axTraitsDelegate2 = delegate; }
 
-typedef bool (* AccessibilityIsElementDelegate)(int32_t);
-typedef bool (* AccessibilityIsElementDelegate2)(uint64_t);
+typedef bool (* AccessibilityIsElementDelegate)(uint64_t);
 static AccessibilityIsElementDelegate __axIsElementDelegate = NULL;
-static AccessibilityIsElementDelegate2 __axIsElementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIsElement(AccessibilityIsElementDelegate delegate) { __axIsElementDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIsElement2(AccessibilityIsElementDelegate2 delegate) { __axIsElementDelegate2 = delegate; }
 
-typedef char *(* AccessibilityHintDelegate)(int32_t);
-typedef char *(* AccessibilityHintDelegate2)(uint64_t);
+typedef char *(* AccessibilityHintDelegate)(uint64_t);
 static AccessibilityHintDelegate __axHintDelegate = NULL;
-static AccessibilityHintDelegate2 __axHintDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityHint(AccessibilityHintDelegate delegate) { __axHintDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityHint2(AccessibilityHintDelegate2 delegate) { __axHintDelegate2 = delegate; }
 
-typedef char *(* AccessibilityValueDelegate)(int32_t);
-typedef char *(* AccessibilityValueDelegate2)(uint64_t);
+typedef char *(* AccessibilityValueDelegate)(uint64_t);
 static AccessibilityValueDelegate __axValueDelegate = NULL;
-static AccessibilityValueDelegate2 __axValueDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityValue(AccessibilityValueDelegate delegate) { __axValueDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityValue2(AccessibilityValueDelegate2 delegate) { __axValueDelegate2 = delegate; }
 
-typedef char *(* AccessibilityIdentifierDelegate)(int32_t);
-typedef char *(* AccessibilityIdentifierDelegate2)(uint64_t);
+typedef char *(* AccessibilityIdentifierDelegate)(uint64_t);
 static AccessibilityIdentifierDelegate __axIdentifierDelegate = NULL;
-static AccessibilityIdentifierDelegate2 __axIdentifierDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIdentifier(AccessibilityIdentifierDelegate delegate) { __axIdentifierDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIdentifier2(AccessibilityIdentifierDelegate2 delegate) { __axIdentifierDelegate2 = delegate; }
 
-typedef bool (* AccessibilityViewIsModalDelegate)(int32_t);
-typedef bool (* AccessibilityViewIsModalDelegate2)(uint64_t);
+typedef bool (* AccessibilityViewIsModalDelegate)(uint64_t);
 static AccessibilityViewIsModalDelegate __axViewIsModalDelegate = NULL;
-static AccessibilityViewIsModalDelegate2 __axViewIsModalDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityViewIsModal(AccessibilityViewIsModalDelegate delegate) { __axViewIsModalDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityViewIsModal2(AccessibilityViewIsModalDelegate2 delegate) { __axViewIsModalDelegate2 = delegate; }
 
-typedef char *(* AccessibilityActivationPointDelegate)(int32_t);
-typedef char *(* AccessibilityActivationPointDelegate2)(uint64_t);
+typedef char *(* AccessibilityActivationPointDelegate)(uint64_t);
 static AccessibilityActivationPointDelegate __axActivationPointDelegate = NULL;
-static AccessibilityActivationPointDelegate2 __axActivationPointDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivationPoint(AccessibilityActivationPointDelegate delegate) { __axActivationPointDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivationPoint2(AccessibilityActivationPointDelegate2 delegate) { __axActivationPointDelegate2 = delegate; }
 
-typedef uint64_t (* AccessibilityCustomActionsCountDelegate)(int32_t);
-typedef uint64_t (* AccessibilityCustomActionsCountDelegate2)(uint64_t);
+typedef uint64_t (* AccessibilityCustomActionsCountDelegate)(uint64_t);
 static AccessibilityCustomActionsCountDelegate __axCustomActionsCountDelegate = NULL;
-static AccessibilityCustomActionsCountDelegate2 __axCustomActionsCountDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionsCount(AccessibilityCustomActionsCountDelegate delegate) { __axCustomActionsCountDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionsCount2(AccessibilityCustomActionsCountDelegate2 delegate) { __axCustomActionsCountDelegate2 = delegate; }
 
-typedef bool (* AccessibilityPerformCustomActionDelegate)(int32_t, int32_t);
-typedef bool (* AccessibilityPerformCustomActionDelegate2)(uint64_t, int32_t);
+typedef bool (* AccessibilityPerformCustomActionDelegate)(uint64_t, int32_t);
 static AccessibilityPerformCustomActionDelegate __axPerformCustomActionDelegate = NULL;
-static AccessibilityPerformCustomActionDelegate2 __axPerformCustomActionDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformCustomAction(AccessibilityPerformCustomActionDelegate delegate) { __axPerformCustomActionDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformCustomAction2(AccessibilityPerformCustomActionDelegate2 delegate) { __axPerformCustomActionDelegate2 = delegate; }
 
-typedef char *(* AccessibilityCustomActionNameDelegate)(int32_t, int32_t);
-typedef char *(* AccessibilityCustomActionNameDelegate2)(uint64_t, int32_t);
+typedef char *(* AccessibilityCustomActionNameDelegate)(uint64_t, int32_t);
 static AccessibilityCustomActionNameDelegate __axCustomActionNameDelegate = NULL;
-static AccessibilityCustomActionNameDelegate2 __axCustomActionNameDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionName(AccessibilityCustomActionNameDelegate delegate) { __axCustomActionNameDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityCustomActionName2(AccessibilityCustomActionNameDelegate2 delegate) { __axCustomActionNameDelegate2 = delegate; }
 
-typedef bool (* AccessibilityScrollDelegate)(int32_t, uint32_t);
-typedef bool (* AccessibilityScrollDelegate2)(uint64_t, uint32_t);
+typedef bool (* AccessibilityScrollDelegate)(uint64_t, uint32_t);
 static AccessibilityScrollDelegate __axScrollDelegate = NULL;
-static AccessibilityScrollDelegate2 __axScrollDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityScroll(AccessibilityScrollDelegate delegate) { __axScrollDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityScroll2(AccessibilityScrollDelegate2 delegate) { __axScrollDelegate2 = delegate; }
 
-typedef bool (* AccessibilityPerformMagicTapDelegate)(int32_t);
-typedef bool (* AccessibilityPerformMagicTapDelegate2)(uint64_t);
+typedef bool (* AccessibilityPerformMagicTapDelegate)(uint64_t);
 static AccessibilityPerformMagicTapDelegate __axPerformMagicTapDelegate = NULL;
-static AccessibilityPerformMagicTapDelegate2 __axPerformMagicTapDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformMagicTap(AccessibilityPerformMagicTapDelegate delegate) { __axPerformMagicTapDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformMagicTap2(AccessibilityPerformMagicTapDelegate2 delegate) { __axPerformMagicTapDelegate2 = delegate; }
 
-typedef bool (* AccessibilityPerformEscapeDelegate)(int32_t);
-typedef bool (* AccessibilityPerformEscapeDelegate2)(uint64_t);
+typedef bool (* AccessibilityPerformEscapeDelegate)(uint64_t);
 static AccessibilityPerformEscapeDelegate __axPerformEscapeDelegate = NULL;
-static AccessibilityPerformEscapeDelegate2 __axPerformEscapeDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformEscape(AccessibilityPerformEscapeDelegate delegate) { __axPerformEscapeDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityPerformEscape2(AccessibilityPerformEscapeDelegate2 delegate) { __axPerformEscapeDelegate2 = delegate; }
 
-typedef bool (* AccessibilityActivateDelegate)(int32_t);
-typedef bool (* AccessibilityActivateDelegate2)(uint64_t);
+typedef bool (* AccessibilityActivateDelegate)(uint64_t);
 static AccessibilityActivateDelegate __axActivateDelegate = NULL;
-static AccessibilityActivateDelegate2 __axActivateDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivate(AccessibilityActivateDelegate delegate) { __axActivateDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityActivate2(AccessibilityActivateDelegate2 delegate) { __axActivateDelegate2 = delegate; }
 
-typedef void (* AccessibilityIncrementDelegate)(int32_t);
-typedef void (* AccessibilityIncrementDelegate2)(uint64_t);
+typedef void (* AccessibilityIncrementDelegate)(uint64_t);
 static AccessibilityIncrementDelegate __axIncrementDelegate = NULL;
-static AccessibilityIncrementDelegate2 __axIncrementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIncrement(AccessibilityIncrementDelegate delegate) { __axIncrementDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityIncrement2(AccessibilityIncrementDelegate2 delegate) { __axIncrementDelegate2 = delegate; }
 
-typedef void (* AccessibilityDecrementDelegate)(int32_t);
-typedef void (* AccessibilityDecrementDelegate2)(uint64_t);
+typedef void (* AccessibilityDecrementDelegate)(uint64_t);
 static AccessibilityDecrementDelegate __axDecrementDelegate = NULL;
-static AccessibilityDecrementDelegate2 __axDecrementDelegate2 = NULL;
 APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityDecrement(AccessibilityDecrementDelegate delegate) { __axDecrementDelegate = delegate; }
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_registerAccessibilityDecrement2(AccessibilityDecrementDelegate2 delegate) { __axDecrementDelegate2 = delegate; }
 
 #pragma mark Settings
 
@@ -606,8 +552,7 @@ APPLE_ACCESSIBILITY_HIDDEN
 
 static _AppleAccessibilityNotificationObserver *_observer;
 
-// The callbackOption parameter represents a hint from Unity about which set of callbacks to use.
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(int32_t callbackOption)
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(void)
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -656,278 +601,139 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_InitializeAXRuntime(int32_t callbackOpt
             [center addObserver:_observer selector:@selector(_accessibilityStatusChangedCallback:) name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification object:nil];
         }
 
-        if (callbackOption == 0)
-        {
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
-                if ( __axFrameDelegate == NULL )
-                {
-                    return CGRectZero;
-                }
-                char *rectStr = __axFrameDelegate((int32_t)identifier.integerValue);
-                return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
-                if ( __axLabelDelegate == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axLabelDelegate((int32_t)identifier.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
-                if ( __axTraitsDelegate == NULL )
-                {
-                    return (uint64_t)0;
-                }
-                return __axTraitsDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
-                if ( __axIsElementDelegate == NULL )
-                {
-                    return YES;
-                }
-                return __axIsElementDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
-                if ( __axHintDelegate == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axHintDelegate((int32_t)identifier.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
-                if ( __axValueDelegate == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axValueDelegate((int32_t)identifier.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
-                if ( __axIdentifierDelegate == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axIdentifierDelegate((int32_t)identifier.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
-                if ( __axViewIsModalDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axViewIsModalDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
-                if ( __axActivationPointDelegate == NULL )
-                {
-                    return kAXCenterPointDefaultPoint;
-                }
-                char *pointStr = __axActivationPointDelegate((int32_t)identifier.integerValue);
-                return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
-                if ( __axCustomActionsCountDelegate == NULL )
-                {
-                    return (uint64_t)0;
-                }
-                return __axCustomActionsCountDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
-                if ( __axPerformCustomActionDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformCustomActionDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
-                if ( __axCustomActionNameDelegate == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axCustomActionNameDelegate((int32_t)identifier.integerValue, (int32_t)idx.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
-                if ( __axScrollDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axScrollDelegate((int32_t)identifier.integerValue, (int32_t)direction);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
-                if ( __axPerformMagicTapDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformMagicTapDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
-                if ( __axPerformEscapeDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformEscapeDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
-                if ( __axActivateDelegate == NULL )
-                {
-                    return NO;
-                }
-                return __axActivateDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
-                if ( __axIncrementDelegate == NULL )
-                {
-                    return;
-                }
-                __axIncrementDelegate((int32_t)identifier.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
-                if ( __axDecrementDelegate == NULL )
-                {
-                    return;
-                }
-                __axDecrementDelegate((int32_t)identifier.integerValue);
-            }];
-        }
-        else if (callbackOption == 2)
-        {
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
-                if ( __axFrameDelegate2 == NULL )
-                {
-                    return CGRectZero;
-                }
-                char *rectStr = __axFrameDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
-                if ( __axLabelDelegate2 == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axLabelDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
-                if ( __axTraitsDelegate2 == NULL )
-                {
-                    return (uint64_t)0;
-                }
-                return __axTraitsDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
-                if ( __axIsElementDelegate2 == NULL )
-                {
-                    return YES;
-                }
-                return __axIsElementDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
-                if ( __axHintDelegate2 == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axHintDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
-                if ( __axValueDelegate2 == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axValueDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
-                if ( __axIdentifierDelegate2 == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axIdentifierDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
-                if ( __axViewIsModalDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axViewIsModalDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
-                if ( __axActivationPointDelegate2 == NULL )
-                {
-                    return kAXCenterPointDefaultPoint;
-                }
-                char *pointStr = __axActivationPointDelegate2((uint64_t)identifier.unsignedLongLongValue);
-                return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
-                if ( __axCustomActionsCountDelegate2 == NULL )
-                {
-                    return (uint64_t)0;
-                }
-                return __axCustomActionsCountDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
-                if ( __axPerformCustomActionDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformCustomActionDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
-                if ( __axCustomActionNameDelegate2 == NULL )
-                {
-                    return nil;
-                }
-                char *str = __axCustomActionNameDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
-                return str == NULL ? nil : [NSString stringWithUTF8String:str];
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
-                if ( __axScrollDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axScrollDelegate2((uint64_t)identifier.unsignedLongLongValue, (int32_t)direction);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
-                if ( __axPerformMagicTapDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformMagicTapDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
-                if ( __axPerformEscapeDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axPerformEscapeDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
-                if ( __axActivateDelegate2 == NULL )
-                {
-                    return NO;
-                }
-                return __axActivateDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
-                if ( __axIncrementDelegate2 == NULL )
-                {
-                    return;
-                }
-                __axIncrementDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-            [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
-                if ( __axDecrementDelegate2 == NULL )
-                {
-                    return;
-                }
-                __axDecrementDelegate2((uint64_t)identifier.unsignedLongLongValue);
-            }];
-        }
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityFrame:^CGRect(NSNumber *identifier) {
+            if ( __axFrameDelegate == NULL )
+            {
+                return CGRectZero;
+            }
+            char *rectStr = __axFrameDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return rectStr == NULL ? CGRectZero : CGRectFromString([NSString stringWithUTF8String:rectStr]);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityLabel:^NSString *(NSNumber *identifier) {
+            if ( __axLabelDelegate == NULL )
+            {
+                return nil;
+            }
+            char *str = __axLabelDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return str == NULL ? nil : [NSString stringWithUTF8String:str];
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityTraits:^UIAccessibilityTraits(NSNumber *identifier) {
+            if ( __axTraitsDelegate == NULL )
+            {
+                return (uint64_t)0;
+            }
+            return __axTraitsDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityIsAccessibilityElement:^BOOL(NSNumber *identifier) {
+            if ( __axIsElementDelegate == NULL )
+            {
+                return YES;
+            }
+            return __axIsElementDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityHint:^NSString *(NSNumber *identifier) {
+            if ( __axHintDelegate == NULL )
+            {
+                return nil;
+            }
+            char *str = __axHintDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return str == NULL ? nil : [NSString stringWithUTF8String:str];
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityValue:^NSString *(NSNumber *identifier) {
+            if ( __axValueDelegate == NULL )
+            {
+                return nil;
+            }
+            char *str = __axValueDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return str == NULL ? nil : [NSString stringWithUTF8String:str];
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIdentifier:^NSString *(NSNumber *identifier) {
+            if ( __axIdentifierDelegate == NULL )
+            {
+                return nil;
+            }
+            char *str = __axIdentifierDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return str == NULL ? nil : [NSString stringWithUTF8String:str];
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityViewIsModal:^BOOL(NSNumber *identifier) {
+            if ( __axViewIsModalDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axViewIsModalDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivationPoint:^CGPoint(NSNumber *identifier) {
+            if ( __axActivationPointDelegate == NULL )
+            {
+                return kAXCenterPointDefaultPoint;
+            }
+            char *pointStr = __axActivationPointDelegate((uint64_t)identifier.unsignedLongLongValue);
+            return pointStr == NULL ? kAXCenterPointDefaultPoint : CGPointFromString([NSString stringWithUTF8String:pointStr]);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityCustomActionsCount:^uint64_t(NSNumber *identifier) {
+            if ( __axCustomActionsCountDelegate == NULL )
+            {
+                return (uint64_t)0;
+            }
+            return __axCustomActionsCountDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityPerformCustomAction:^BOOL(NSNumber *identifier, NSNumber *idx) {
+            if ( __axPerformCustomActionDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axPerformCustomActionDelegate((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityCustomActionName:^NSString *(NSNumber *identifier, NSNumber *idx) {
+            if ( __axCustomActionNameDelegate == NULL )
+            {
+                return nil;
+            }
+            char *str = __axCustomActionNameDelegate((uint64_t)identifier.unsignedLongLongValue, (int32_t)idx.integerValue);
+            return str == NULL ? nil : [NSString stringWithUTF8String:str];
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityScroll:^BOOL(NSNumber *identifier, UIAccessibilityScrollDirection direction) {
+            if ( __axScrollDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axScrollDelegate((uint64_t)identifier.unsignedLongLongValue, (int32_t)direction);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformMagicTap:^BOOL(NSNumber *identifier) {
+            if ( __axPerformMagicTapDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axPerformMagicTapDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityPerformEscape:^BOOL(NSNumber *identifier) {
+            if ( __axPerformEscapeDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axPerformEscapeDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityActivate:^BOOL(NSNumber *identifier) {
+            if ( __axActivateDelegate == NULL )
+            {
+                return NO;
+            }
+            return __axActivateDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityIncrement:^void(NSNumber *identifier) {
+            if ( __axIncrementDelegate == NULL )
+            {
+                return;
+            }
+            __axIncrementDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
+        [AppleAccessibilityRuntime.sharedInstance setUnityAccessibilityDecrement:^void(NSNumber *identifier) {
+            if ( __axDecrementDelegate == NULL )
+            {
+                return;
+            }
+            __axDecrementDelegate((uint64_t)identifier.unsignedLongLongValue);
+        }];
     });
 }
 
@@ -936,22 +742,12 @@ APPLE_ACCESSIBILITY_EXTERN void _UnityAX_PostUnityViewChanged(void)
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
 
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_RegisterElementWithIdentifier(int32_t identifier, int32_t parentIdentifier, bool hasParent)
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_RegisterElementWithIdentifier(uint64_t identifier, uint64_t parentIdentifier, bool hasParent)
 {
     [AppleAccessibilityRuntime.sharedInstance registerAccessibilityElementWithIdentifier:@(identifier) parent: hasParent ? @(parentIdentifier) : nil hasParent:hasParent];
 }
 
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_RegisterElementWithIdentifier2(uint64_t identifier, uint64_t parentIdentifier, bool hasParent)
-{
-    [AppleAccessibilityRuntime.sharedInstance registerAccessibilityElementWithIdentifier:@(identifier) parent: hasParent ? @(parentIdentifier) : nil hasParent:hasParent];
-}
-
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_UnregisterElementWithIdentifier(int32_t identifier)
-{
-    [AppleAccessibilityRuntime.sharedInstance unregisterAccessibilityElementWithIdentifier:@(identifier)];
-}
-
-APPLE_ACCESSIBILITY_EXTERN void _UnityAX_UnregisterElementWithIdentifier2(uint64_t identifier)
+APPLE_ACCESSIBILITY_EXTERN void _UnityAX_UnregisterElementWithIdentifier(uint64_t identifier)
 {
     [AppleAccessibilityRuntime.sharedInstance unregisterAccessibilityElementWithIdentifier:@(identifier)];
 }
@@ -961,12 +757,7 @@ APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithName(const char *
     return [AppleAccessibilityRuntime.sharedInstance runUnitTestWithName:[NSString stringWithUTF8String:name]];
 }
 
-APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(int32_t identifier, const char *keyPath, const char *expected)
-{
-    return [AppleAccessibilityRuntime.sharedInstance runUnitTestForIdentifier:@(identifier) keyPath:[NSString stringWithUTF8String:keyPath] expected:[NSString stringWithUTF8String:expected]];
-}
-
-APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult2(uint64_t identifier, const char *keyPath, const char *expected)
+APPLE_ACCESSIBILITY_EXTERN bool _UnityAX_RuniOSSideUnitTestWithKeyPathExpectingStringResult(uint64_t identifier, const char *keyPath, const char *expected)
 {
     return [AppleAccessibilityRuntime.sharedInstance runUnitTestForIdentifier:@(identifier) keyPath:[NSString stringWithUTF8String:keyPath] expected:[NSString stringWithUTF8String:expected]];
 }

--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuildProfileEditor.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleBuildProfileEditor.cs
@@ -180,7 +180,11 @@ namespace Apple.Core
                 {
                     if (_serializedDefaultInfoPlist.objectReferenceValue != null)
                     {
+#if UNITY_6000_4_OR_NEWER
+                        string filePath = AssetDatabase.GetAssetPath(_serializedDefaultInfoPlist.objectReferenceValue.GetEntityId());
+#else
                         string filePath = AssetDatabase.GetAssetPath(_serializedDefaultInfoPlist.objectReferenceValue.GetInstanceID());
+#endif
                         if (!filePath.EndsWith(".plist"))
                         {
                             _serializedDefaultInfoPlist.objectReferenceValue = null;
@@ -232,7 +236,11 @@ namespace Apple.Core
                 EditorGUILayout.ObjectField(_serializedDefaultEntitlements, typeof(UnityEngine.Object), defaultEntitlementsLabel, GUILayout.MinWidth(_minLabelWidth));
                 if (EditorGUI.EndChangeCheck() && !(_serializedDefaultEntitlements.objectReferenceValue is null))
                 {
+#if UNITY_6000_4_OR_NEWER
+                    string filePath = AssetDatabase.GetAssetPath(_serializedDefaultEntitlements.objectReferenceValue.GetEntityId());
+#else
                     string filePath = AssetDatabase.GetAssetPath(_serializedDefaultEntitlements.objectReferenceValue.GetInstanceID());
+#endif
                     if (!filePath.EndsWith(".entitlements"))
                     {
                         _serializedDefaultEntitlements.objectReferenceValue = null;

--- a/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPicker.cs
+++ b/plug-ins/Apple.CoreHaptics/Apple.CoreHaptics_Unity/Assets/Apple.CoreHaptics/Editor/UnityPickers/AssetPicker.cs
@@ -129,7 +129,11 @@ namespace UnityPickers
 		[SerializeField]
 		private string nameFilter;
 
+#if UNITY_6000_4_OR_NEWER
+		private HierarchyIterator hierarchyIterator;
+#else
 		private HierarchyProperty hierarchyProperty;
+#endif
 
 		private List<HierarchyEntry> loadedAssets;
 
@@ -251,7 +255,11 @@ namespace UnityPickers
 				buttonPos.xMin = buttonPos.xMax - EditorGUIUtility.singleLineHeight;
 				var requesterWindow = focusedWindow;
 
+#if UNITY_6000_4_OR_NEWER
+				string controlName = property.serializedObject.targetObject.GetEntityId() + "_" + property.propertyPath;
+#else
 				string controlName = property.serializedObject.targetObject.GetInstanceID() + "_" + property.propertyPath;
+#endif
 				var e = Event.current;
 				bool showHotKey =
 					GUI.GetNameOfFocusedControl() == controlName &&
@@ -929,6 +937,15 @@ namespace UnityPickers
 			loadedAssets = new List<HierarchyEntry>();
 			loadedAssetsFlat.Clear();
 
+#if UNITY_6000_4_OR_NEWER
+			hierarchyIterator = new HierarchyIterator(HierarchyType.Assets);
+			hierarchyIterator.SetSearchFilter(GetFilter(), (int)SearchableEditorWindow.SearchMode.All);
+
+			while (hierarchyIterator.Next(null))
+			{
+				AddAssetInfo(hierarchyIterator);
+			}
+#else
 			hierarchyProperty = new HierarchyProperty(HierarchyType.Assets);
 			hierarchyProperty.SetSearchFilter(GetFilter(), (int)SearchableEditorWindow.SearchMode.All);
 
@@ -936,6 +953,7 @@ namespace UnityPickers
 			{
 				AddAssetInfo(hierarchyProperty);
 			}
+#endif
 
 			FilterAssets(ref loadedAssets);
 			loadedAssets.ForEach(SortChildren);
@@ -967,9 +985,15 @@ namespace UnityPickers
 	        return stringBuilder.ToString();
 	    }
 
+#if UNITY_6000_4_OR_NEWER
+		private void AddAssetInfo(HierarchyIterator hi)
+		{ 
+			var path = AssetDatabase.GUIDToAssetPath(hi.guid);
+#else
 		private void AddAssetInfo(HierarchyProperty hp)
 		{
 			var path = AssetDatabase.GUIDToAssetPath(hp.guid);
+#endif
 			var folders = path.Split('/');
 			var list = loadedAssets;
 			HierarchyEntry parent = null;
@@ -993,10 +1017,17 @@ namespace UnityPickers
 			}
 			var hierarchyEntry = new HierarchyEntry
 			{
+#if UNITY_6000_4_OR_NEWER
+				Parent = parent,
+				Name = hi.name,
+				Path = path,
+				AssetGuid = hi.guid,
+#else
 				Parent = parent,
 				Name = hp.name,
 				Path = path,
 				AssetGuid = hp.guid,
+#endif
 			};
 			list.Add(hierarchyEntry);
 		}

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Editor/UnityPickers/AssetPicker.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Editor/UnityPickers/AssetPicker.cs
@@ -129,9 +129,13 @@ namespace UnityPickers
 		[SerializeField]
 		private string nameFilter;
 
+#if UNITY_6000_4_OR_NEWER
+        private HierarchyIterator hierarchyIterator;
+#else
 		private HierarchyProperty hierarchyProperty;
+#endif
 
-		private List<HierarchyEntry> loadedAssets;
+        private List<HierarchyEntry> loadedAssets;
 
 		private readonly List<HierarchyEntry> loadedAssetsFlat = new List<HierarchyEntry>();
 
@@ -249,8 +253,12 @@ namespace UnityPickers
 				buttonPos.xMin = buttonPos.xMax - EditorGUIUtility.singleLineHeight;
 				var requesterWindow = focusedWindow;
 
+#if UNITY_6000_4_OR_NEWER
+                string controlName = property.serializedObject.targetObject.GetEntityId() + "_" + property.propertyPath;
+#else
 				string controlName = property.serializedObject.targetObject.GetInstanceID() + "_" + property.propertyPath;
-				var e = Event.current;
+#endif
+                var e = Event.current;
 				bool showHotKey =
 					GUI.GetNameOfFocusedControl() == controlName &&
 					e.type == EventType.KeyDown &&
@@ -919,6 +927,15 @@ namespace UnityPickers
 			loadedAssets = new List<HierarchyEntry>();
 			loadedAssetsFlat.Clear();
 
+#if UNITY_6000_4_OR_NEWER
+            hierarchyIterator = new HierarchyIterator(HierarchyType.Assets);
+            hierarchyIterator.SetSearchFilter(GetFilter(), (int)SearchableEditorWindow.SearchMode.All);
+
+            while (hierarchyIterator.Next(null))
+            {
+                AddAssetInfo(hierarchyIterator);
+            }
+#else
 			hierarchyProperty = new HierarchyProperty(HierarchyType.Assets);
 			hierarchyProperty.SetSearchFilter(GetFilter(), (int)SearchableEditorWindow.SearchMode.All);
 
@@ -926,8 +943,9 @@ namespace UnityPickers
 			{
 				AddAssetInfo(hierarchyProperty);
 			}
+#endif
 
-			FilterAssets(ref loadedAssets);
+            FilterAssets(ref loadedAssets);
 			loadedAssets.ForEach(SortChildren);
 
 			loadedAssetsFlat.Clear();
@@ -957,10 +975,18 @@ namespace UnityPickers
 	        return stringBuilder.ToString();
 	    }
 
-		private void AddAssetInfo(HierarchyProperty hp)
+#if UNITY_6000_4_OR_NEWER
+        private void AddAssetInfo(HierarchyIterator hi)
+#else
+        private void AddAssetInfo(HierarchyProperty hp)
+#endif
 		{
+#if UNITY_6000_4_OR_NEWER
+            var path = AssetDatabase.GUIDToAssetPath(hi.guid);
+#else
 			var path = AssetDatabase.GUIDToAssetPath(hp.guid);
-			var folders = path.Split('/');
+#endif
+            var folders = path.Split('/');
 			var list = loadedAssets;
 			HierarchyEntry parent = null;
 			for (int ii = 1; ii < folders.Length - 1; ii++) // 1 to skip Assets folder, -1 to skip asset name
@@ -984,10 +1010,18 @@ namespace UnityPickers
 			var hierarchyEntry = new HierarchyEntry
 			{
 				Parent = parent,
-				Name = hp.name,
-				Path = path,
-				AssetGuid = hp.guid,
-			};
+#if UNITY_6000_4_OR_NEWER
+                Name = hi.name,
+#else
+                Name = hp.name,
+#endif
+                Path = path,
+#if UNITY_6000_4_OR_NEWER
+                AssetGuid = hi.guid,
+#else
+                AssetGuid = hp.guid,
+#endif
+            };
 			list.Add(hierarchyEntry);
 		}
 

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Runtime/PHASEListener.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Runtime/PHASEListener.cs
@@ -242,7 +242,11 @@ namespace Apple.PHASE
                 if (entry is PHASESpatialMixer)
                 {
                     PHASESpatialMixer mixer = entry as PHASESpatialMixer;
+#if UNITY_6000_4_OR_NEWER
+                    if (Selection.Contains(mixer.GetEntityId()))
+#else
                     if (Selection.Contains(mixer.GetInstanceID()))
+#endif
                     {
                         Helpers.DirectivityModelSubbandParameters subbandParameters = mixer.GetListenerDirectivityModelSubbandParameters();
                         switch (mixer.GetListenerDirectivityType())

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Runtime/PHASESource.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Runtime/PHASESource.cs
@@ -473,7 +473,12 @@ namespace Apple.PHASE
                 if (entry is PHASESpatialMixer)
                 {
                     PHASESpatialMixer mixer = entry as PHASESpatialMixer;
+
+#if UNITY_6000_4_OR_NEWER
+                    if (Selection.Contains(mixer.GetEntityId()))
+#else
                     if (Selection.Contains(mixer.GetInstanceID()))
+#endif
                     {
                         Helpers.DirectivityModelSubbandParameters subbandParameters = mixer.GetSourceDirectivityModelSubbandParameters();
                         switch (mixer.GetSourceDirectivityType())

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Tests/Runtime/PHASETests.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/Tests/Runtime/PHASETests.cs
@@ -35,7 +35,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, $"Failed to create {testSourceName}");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, $"Failed to create {testSourceName}");
+#endif
 
             source.Play();
             yield return new WaitForFixedUpdate();
@@ -59,7 +63,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -86,7 +94,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create Footsteps");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create Footsteps");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.5f);
@@ -116,7 +128,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -143,7 +159,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -182,7 +202,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -213,7 +237,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -244,7 +272,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.05f);
@@ -270,7 +302,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -310,7 +346,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);
@@ -341,7 +381,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.5f);
@@ -370,7 +414,11 @@ namespace Apple.PHASE.UnitTests
 
             PHASESource source = sourceObject.GetComponent<PHASESource>();
             yield return new WaitForFixedUpdate();
+#if UNITY_6000_4_OR_NEWER
+            Assert.IsTrue(source.GetEntityId() != EntityId.None, "Failed to create looping source");
+#else
             Assert.IsTrue(source.GetInstanceID() != InvalidId, "Failed to create looping source");
+#endif
 
             source.Play();
             yield return new WaitForSeconds(0.75f);

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/xNode/Editor/NodeEditorUtilities.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/xNode/Editor/NodeEditorUtilities.cs
@@ -265,7 +265,11 @@ namespace XNodeEditor {
 
         public static void CreateFromTemplate(string initialName, string templatePath) {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+#if UNITY_6000_4_OR_NEWER
+                EntityId.None,
+#else
                 0,
+#endif
                 ScriptableObject.CreateInstance<DoCreateCodeFile>(),
                 initialName,
                 scriptIcon,
@@ -273,9 +277,15 @@ namespace XNodeEditor {
             );
         }
 
+#if UNITY_6000_4_OR_NEWER
+        /// Inherits from AssetCreationEndAction, must override AssetCreationEndAction.Action
+        public class DoCreateCodeFile : UnityEditor.ProjectWindowCallback.AssetCreationEndAction {
+            public override void Action(EntityId entityId, string pathName, string resourceFile) {
+#else
         /// Inherits from EndNameAction, must override EndNameAction.Action
         public class DoCreateCodeFile : UnityEditor.ProjectWindowCallback.EndNameEditAction {
             public override void Action(int instanceId, string pathName, string resourceFile) {
+#endif
                 Object o = CreateScript(pathName, resourceFile);
                 ProjectWindowUtil.ShowCreatedAsset(o);
             }

--- a/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/xNode/Editor/NodeEditorWindow.cs
+++ b/plug-ins/Apple.PHASE/Apple.PHASE_Unity/Assets/xNode/Editor/NodeEditorWindow.cs
@@ -186,8 +186,13 @@ namespace XNodeEditor {
         }
 
         [OnOpenAsset(0)]
+#if UNITY_6000_4_OR_NEWER
+        public static bool OnOpen(EntityId entityId, int line) {
+            XNode.NodeGraph nodeGraph = EditorUtility.EntityIdToObject(entityId) as XNode.NodeGraph;
+#else
         public static bool OnOpen(int instanceID, int line) {
             XNode.NodeGraph nodeGraph = EditorUtility.InstanceIDToObject(instanceID) as XNode.NodeGraph;
+#endif
             if (nodeGraph != null) {
                 Open(nodeGraph);
                 return true;


### PR DESCRIPTION
A script in the Apple.Core plugin contains a method that becomes obsolete in Unity 6000.4 and newer versions, causing an error.
In that case, GetEntityId() must be used instead.

Fixes apple/unityplugins#102